### PR TITLE
Add on-page Meet the Coaches section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Endless Vocals — Declare Your New Vocal Life</title>
+    <title>Endless Vocals — Your Vocals Don’t Expire</title>
     <meta name="description" content="Endless Vocals is a practical, modern vocal school by Ryan Wall and Tiago Costa. Two‑month bootcamps, live sessions + replays, and a free Discord community." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -28,6 +28,7 @@
             background: var(--bg);
             color: var(--fg);
             font-family: Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif;
+            scroll-behavior: smooth;
         }
 
         a {
@@ -58,6 +59,12 @@
             margin-bottom: 28px
         }
 
+        .masthead-info {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
         .logo {
             font-weight: 800;
             letter-spacing: 2px;
@@ -69,6 +76,26 @@
             color: var(--muted)
         }
 
+        .masthead-nav {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            font-size: 15px;
+        }
+
+            .masthead-nav a {
+                color: var(--muted);
+                padding: 8px 12px;
+                border-radius: 12px;
+                transition: background .2s ease, color .2s ease;
+            }
+
+            .masthead-nav a:focus,
+            .masthead-nav a:hover {
+                color: var(--fg);
+                background: rgba(255,255,255,.06);
+            }
+
         .title {
             font-size: clamp(36px, 4.5vw, 72px);
             line-height: 1.05;
@@ -79,7 +106,7 @@
         .subtitle {
             font-size: clamp(16px, 2.2vw, 20px);
             color: var(--muted);
-            max-width: 48ch
+            max-width: 60ch
         }
 
         .cta-row {
@@ -114,6 +141,12 @@
         .btn:focus {
             outline: 3px solid rgba(255,255,255,.2);
             outline-offset: 2px
+        }
+
+        .btn-ghost {
+            background: rgba(255,255,255,.08);
+            border: 1px solid rgba(255,255,255,.16);
+            color: var(--fg);
         }
 
         .grid {
@@ -178,9 +211,100 @@
             color: #bdb9b2
         }
 
+        .coaches-section {
+            margin-top: 64px;
+        }
+
+            .coaches-section header {
+                text-align: center;
+                margin-bottom: 36px;
+            }
+
+            .coaches-title {
+                font-size: clamp(32px, 4vw, 54px);
+                margin: 0 0 12px;
+                font-weight: 800;
+            }
+
+            .coaches-intro {
+                margin: 0 auto;
+                max-width: 70ch;
+                color: var(--muted);
+                font-size: 18px;
+            }
+
+        .coach-grid {
+            display: grid;
+            gap: 22px;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        }
+
+        .coach-card {
+            background: #121217;
+            border: 1px solid #26262f;
+            border-radius: 18px;
+            padding: 26px;
+            box-shadow: 0 10px 28px rgba(0,0,0,.25);
+        }
+
+            .coach-card h3 {
+                margin: 0 0 12px;
+                font-size: 24px;
+            }
+
+            .coach-card h4 {
+                margin: 0 0 16px;
+                color: var(--accent-2);
+                font-size: 16px;
+                letter-spacing: .4px;
+                text-transform: uppercase;
+            }
+
+            .coach-card p {
+                margin: 0 0 14px;
+                line-height: 1.6;
+                color: #d7d4ce;
+            }
+
+            .coach-card a {
+                color: var(--accent);
+                text-decoration: underline;
+            }
+
         @media (max-width: 880px) {
             .grid {
                 grid-template-columns: 1fr;
+            }
+        }
+
+        @media (max-width: 600px) {
+            .container {
+                padding: 0;
+            }
+
+            .masthead,
+            .footer {
+                padding: 24px;
+            }
+
+            .masthead {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .masthead-nav {
+                padding-left: 0;
+                margin-top: 8px;
+            }
+
+            .hero {
+                margin: 0;
+                border-radius: 0;
+                padding: 48px 24px;
+            }
+
+            .sticky .wrap {
+                max-width: none;
             }
         }
         /* Sticky mobile footer CTA */
@@ -211,19 +335,27 @@
 <body>
     <div class="container">
         <header class="masthead" aria-label="Site header">
-            <div class="logo" aria-label="Endless Vocals">ENDLESS <span style="opacity:.7;font-weight:600">vocals</span></div>
-            <div class="badge">Two‑Month Bootcamps • Free Discord</div>
+            <div class="masthead-info">
+                <div class="logo" aria-label="Endless Vocals">ENDLESS <span style="opacity:.7;font-weight:600">vocals</span></div>
+                <div class="badge">Two‑Month Bootcamps • Free Discord</div>
+            </div>
+            <nav class="masthead-nav" aria-label="Main navigation">
+                <a href="#coaches">Meet the Coaches</a>
+            </nav>
         </header>
 
         <section class="hero" aria-labelledby="h1">
-            <h1 id="h1" class="title">Declare Your New Vocal Life</h1>
+            <h1 id="h1" class="title">Your Vocals Don’t Expire</h1>
             <p class="subtitle">Practical training, clear structure, steady progress. Two‑month bootcamps with Ryan Wall and Tiago Costa. Live sessions, replays, and a friendly Discord to keep you moving.</p>
             <div class="cta-row" role="group" aria-label="Primary actions">
                 <a class="btn btn-primary" href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener noreferrer" aria-label="Sign up at Ko‑fi">
                     <span>Sign Up at Ko‑fi — $24/mo</span>
                 </a>
-                <a class="btn btn-secondary" href="https://discord.gg/" target="_blank" rel="noopener noreferrer" aria-label="Join the Discord">
+                <a class="btn btn-secondary" href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener noreferrer" aria-label="Join the Discord">
                     <span>Join the Discord (Free)</span>
+                </a>
+                <a class="btn btn-ghost" href="#coaches" aria-label="Meet the coaches">
+                    <span>Meet the Coaches</span>
                 </a>
             </div>
 
@@ -255,11 +387,41 @@
             <section class="card" aria-labelledby="how">
                 <h3 id="how">How it works</h3>
                 <ol>
-                    <li style="margin:8px 0">Join the <a href="https://discord.gg/" target="_blank" rel="noopener">Discord</a> (free) to see schedules, share clips, and meet the community.</li>
+                    <li style="margin:8px 0">Join the <a href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener">Discord</a> (free) to see schedules, share clips, and meet the community.</li>
                     <li style="margin:8px 0">When you’re ready, enroll in a <a href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener">Two‑Month Bootcamp</a> ($24/month via Ko‑fi). Attend live or watch replays—your pace.</li>
                     <li style="margin:8px 0">Follow the weekly checklist. Short, repeatable sessions beat long, rare ones.</li>
                 </ol>
             </section>
+        </section>
+
+        <section id="coaches" class="coaches-section" aria-labelledby="coaches-title">
+            <header>
+                <h2 id="coaches-title" class="coaches-title">Meet the Coaches</h2>
+                <p class="coaches-intro">Endless Vocals is powered by a small, dedicated team of vocal experts who blend technical precision, stage-tested experience, and creative mentorship to help you grow.</p>
+            </header>
+
+            <div class="coach-grid" role="list">
+                <article class="coach-card" role="listitem" aria-labelledby="coach-ryan">
+                    <h3 id="coach-ryan">Ryan Wall</h3>
+                    <h4>Head Coach &amp; Founder</h4>
+                    <p>Ryan Wall is a singer, songwriter, and long-time vocal coach who spent a decade teaching alongside Jaime Vendera as Chief Coach of the Vendera Vocal Academy. With over 20 years of songwriting experience and multiple albums to his name, Ryan brings a deep creative perspective to his teaching.</p>
+                    <p>Through Endless Vocals, he not only helps singers strengthen and protect their voices but also guides them in the art of writing and producing original music—skills he shares directly with members of the Discord community. His coaching blends technical precision, stage experience, and creative mentorship to help every vocalist find their unique voice and message.</p>
+                </article>
+
+                <article class="coach-card" role="listitem" aria-labelledby="coach-tiago">
+                    <h3 id="coach-tiago">Tiago Costa</h3>
+                    <h4>Coach &amp; Artist</h4>
+                    <p>Tiago Costa is a dynamic vocalist, guitarist, and multi-instrumentalist known for his work with Firemage and Xeque Mate. His background spans rock, metal, and folk metal, giving him a broad stylistic reach and deep stage experience.</p>
+                    <p>Within Endless Vocals, Tiago focuses on expression, authenticity, and turning raw technique into art. His guitar and musicianship training will also play a role in future bootcamps, connecting vocal control with instrumental understanding. Tiago’s goal is to help singers develop tone, emotion, and confidence—on stage, in the studio, and in themselves.</p>
+                </article>
+
+                <article class="coach-card" role="listitem" aria-labelledby="coach-jaime">
+                    <h3 id="coach-jaime">Jaime Vendera</h3>
+                    <h4>Mentor &amp; Originator of the ISO Method</h4>
+                    <p>Jaime Vendera is an internationally recognized vocal coach, author of <em>Raise Your Voice</em>, and creator of the ISO Method. He has trained countless singers and professionals around the world, known for his legendary glass-shattering demonstrations and focus on vocal health.</p>
+                    <p>Though VVA has come to a close, Jaime continues to inspire and mentor Ryan and Tiago, giving Endless Vocals his full blessing to carry the ISO legacy forward. While Jaime isn't directly involved in Endless Vocals, his website is worth exploring as a bastion for singers: <a href="https://www.jaimevendera.com" target="_blank" rel="noopener">jaimevendera.com</a>.</p>
+                </article>
+            </div>
         </section>
 
         <footer class="footer" aria-label="Site footer">
@@ -271,7 +433,7 @@
     <div class="sticky" role="group" aria-label="Mobile actions">
         <div class="wrap">
             <a class="btn btn-primary" style="flex:1" href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener">Sign Up — Ko‑fi</a>
-            <a class="btn btn-secondary" style="flex:1" href="https://discord.gg/" target="_blank" rel="noopener">Join Discord</a>
+            <a class="btn btn-secondary" style="flex:1" href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener">Join Discord</a>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add a Meet the Coaches anchor section with bios for Ryan, Tiago, and Jaime below the hero content
- add navigation and hero CTA links that smoothly scroll to the new section while keeping the layout responsive on mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e599e24b088331881bbf64a5d7464d