### PR TITLE
Add Meet the Coaches section with decorative assets

### DIFF
--- a/images/coaches/jaime-vendera.svg
+++ b/images/coaches/jaime-vendera.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 420" role="img" aria-labelledby="title desc">
+  <title id="title">Stylized portrait placeholder for Jaime Vendera</title>
+  <desc id="desc">Geometric illustration representing mentor Jaime Vendera.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1d1f24" />
+      <stop offset="100%" stop-color="#121318" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#b6b2aa" />
+      <stop offset="100%" stop-color="#6f6b66" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="420" rx="32" fill="url(#bg)" />
+  <circle cx="300" cy="170" r="92" fill="#2a2c33" />
+  <rect x="210" y="260" width="180" height="110" rx="48" fill="#3a3d44" opacity="0.7" />
+  <path d="M170 340c26-44 90-82 130-82s104 38 130 82l-30 40H200z" fill="url(#accent)" opacity="0.45" />
+  <text x="300" y="372" text-anchor="middle" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="34" fill="#d8d5cf" font-weight="600">Jaime Vendera</text>
+  <text x="300" y="406" text-anchor="middle" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="18" fill="#a3a19b" letter-spacing="4">ISO MENTOR</text>
+</svg>

--- a/images/coaches/ryan-wall.svg
+++ b/images/coaches/ryan-wall.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 420" role="img" aria-labelledby="title desc">
+  <title id="title">Stylized portrait placeholder for Ryan Wall</title>
+  <desc id="desc">Geometric illustration representing vocal coach Ryan Wall.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1b2233" />
+      <stop offset="100%" stop-color="#101520" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#23d3cf" />
+      <stop offset="100%" stop-color="#128480" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="420" rx="32" fill="url(#bg)" />
+  <circle cx="300" cy="170" r="96" fill="#233147" />
+  <ellipse cx="300" cy="165" rx="74" ry="78" fill="#2f415f" />
+  <path d="M220 280c22-36 70-58 80-58s58 22 80 58v72H220z" fill="#162130" />
+  <path d="M180 340c30-44 82-70 120-70s90 26 120 70v40H180z" fill="url(#accent)" opacity="0.7" />
+  <text x="300" y="380" text-anchor="middle" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="36" fill="#f5f2ed" font-weight="700">Ryan Wall</text>
+</svg>

--- a/images/coaches/tiago-costa.svg
+++ b/images/coaches/tiago-costa.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 420" role="img" aria-labelledby="title desc">
+  <title id="title">Stylized portrait placeholder for Tiago Costa</title>
+  <desc id="desc">Geometric illustration representing vocal coach and artist Tiago Costa.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2a163a" />
+      <stop offset="100%" stop-color="#140d22" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f08dbb" />
+      <stop offset="100%" stop-color="#c25f94" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="420" rx="32" fill="url(#bg)" />
+  <circle cx="220" cy="180" r="88" fill="#351e4f" />
+  <circle cx="360" cy="180" r="88" fill="#3f255d" />
+  <rect x="180" y="248" width="240" height="132" rx="60" fill="url(#accent)" opacity="0.85" />
+  <path d="M160 340l120-72 160 72-40 40H200z" fill="#8d4b8f" opacity="0.5" />
+  <text x="300" y="380" text-anchor="middle" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="36" fill="#f5f2ed" font-weight="700">Tiago Costa</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
             box-sizing: border-box
         }
 
+        html {
+            scroll-behavior: smooth;
+        }
+
         html, body {
             margin: 0;
             padding: 0;
@@ -50,13 +54,71 @@
             box-shadow: 0 20px 60px rgba(0,0,0,.35);
         }
 
+            .hero-content {
+                position: relative;
+                z-index: 2;
+            }
+
+            .hero .mic {
+                position: absolute;
+                width: clamp(48px, 8vw, 72px);
+                opacity: .55;
+                filter: drop-shadow(0 8px 22px rgba(0,0,0,.35));
+                z-index: 1;
+                pointer-events: none;
+            }
+
+                .mic.mic-gold {
+                    top: 26px;
+                    left: 20px;
+                }
+
+                .mic.mic-pink {
+                    top: 70px;
+                    right: 38px;
+                }
+
+                .mic.mic-turqoise {
+                    bottom: 34px;
+                    left: 15%;
+                }
+
+                .mic.mic-purple {
+                    bottom: 60px;
+                    right: 12%;
+                }
+
         .masthead {
             display: flex;
             align-items: center;
             justify-content: space-between;
             gap: 16px;
+            flex-wrap: wrap;
             margin-bottom: 28px
         }
+
+            .masthead nav {
+                display: flex;
+                gap: 16px;
+                font-size: 14px;
+                font-weight: 600;
+                letter-spacing: .3px;
+            }
+
+                .masthead nav a {
+                    padding: 10px 14px;
+                    border-radius: 999px;
+                    background: rgba(255,255,255,.05);
+                    color: var(--fg);
+                    border: 1px solid rgba(255,255,255,.08);
+                    transition: background .2s ease, transform .2s ease;
+                }
+
+                .masthead nav a:focus,
+                .masthead nav a:hover {
+                    background: rgba(255,255,255,.12);
+                    transform: translateY(-1px);
+                }
 
         .logo {
             font-weight: 800;
@@ -111,6 +173,12 @@
             color: #2d0f20
         }
 
+        .btn-ghost {
+            background: rgba(255,255,255,.05);
+            color: var(--fg);
+            border: 1px solid rgba(255,255,255,.12);
+        }
+
         .btn:focus {
             outline: 3px solid rgba(255,255,255,.2);
             outline-offset: 2px
@@ -138,6 +206,105 @@
             height: 1px;
             background: #22242a;
             margin: 40px 0
+        }
+
+        .coaches {
+            margin-top: 64px;
+        }
+
+            .coaches h2 {
+                font-size: clamp(32px, 4vw, 48px);
+                margin-bottom: 12px;
+            }
+
+            .coaches p.lead {
+                color: var(--muted);
+                max-width: 68ch;
+                margin-bottom: 40px;
+            }
+
+        .coach-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 24px;
+        }
+
+            .coach-card {
+                background: #121217;
+                border: 1px solid #1f2028;
+                border-radius: 18px;
+                padding: 24px;
+                position: relative;
+                overflow: hidden;
+            }
+
+                .coach-card > *:not(.mic-deco) {
+                    position: relative;
+                    z-index: 1;
+                }
+
+                .coach-card h3 {
+                    margin: 0 0 6px;
+                    font-size: 20px;
+                }
+
+                .coach-card .role {
+                    display: block;
+                    color: var(--accent);
+                    font-size: 14px;
+                    letter-spacing: .4px;
+                    text-transform: uppercase;
+                    margin-bottom: 16px;
+                    font-weight: 600;
+                }
+
+                .coach-card p {
+                    font-size: 15px;
+                    line-height: 1.6;
+                    color: #d8d5cf;
+                }
+
+                .coach-card figure {
+                    margin: 22px 0 0;
+                    border-radius: 16px;
+                    overflow: hidden;
+                    border: 1px solid rgba(255,255,255,.08);
+                    box-shadow: 0 18px 40px rgba(0,0,0,.45);
+                }
+
+                    .coach-card figure img {
+                        display: block;
+                        width: 100%;
+                        height: auto;
+                    }
+
+        .coach-card.mentor {
+            background: rgba(18,18,23,.6);
+            border: 1px dashed rgba(189,185,178,.35);
+            color: #bcb8b2;
+        }
+
+            .coach-card.mentor .role {
+                color: #c5c1ba;
+            }
+
+            .coach-card.mentor p {
+                color: #b0aca6;
+            }
+
+            .coach-card.mentor a {
+                color: var(--accent-2);
+                text-decoration: underline;
+            }
+
+        .coach-card .mic-deco {
+            position: absolute;
+            width: 58px;
+            opacity: .35;
+            right: 18px;
+            bottom: 18px;
+            pointer-events: none;
+            z-index: 0;
         }
 
         .footer {
@@ -182,6 +349,10 @@
             .grid {
                 grid-template-columns: 1fr;
             }
+
+            .coach-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
         }
 
         @media (max-width: 600px) {
@@ -198,6 +369,10 @@
                 margin: 0;
                 border-radius: 0;
                 padding: 48px 24px;
+            }
+
+            .coach-grid {
+                grid-template-columns: 1fr;
             }
 
             .sticky .wrap {
@@ -232,55 +407,104 @@
 <body>
     <div class="container">
         <header class="masthead" aria-label="Site header">
-            <div class="logo" aria-label="Endless Vocals">ENDLESS <span style="opacity:.7;font-weight:600">vocals</span></div>
-            <div class="badge">Two‑Month Bootcamps • Free Discord</div>
+            <div>
+                <div class="logo" aria-label="Endless Vocals">ENDLESS <span style="opacity:.7;font-weight:600">vocals</span></div>
+                <div class="badge">Two‑Month Bootcamps • Free Discord</div>
+            </div>
+            <nav aria-label="Primary navigation">
+                <a href="#coaches">Meet the Coaches</a>
+            </nav>
         </header>
 
         <section class="hero" aria-labelledby="h1">
-            <h1 id="h1" class="title">Your Vocals Don’t Expire</h1>
-            <p class="subtitle">Practical training, clear structure, steady progress. Two‑month bootcamps with Ryan Wall and Tiago Costa. Live sessions, replays, and a friendly Discord to keep you moving.</p>
-            <div class="cta-row" role="group" aria-label="Primary actions">
-                <a class="btn btn-primary" href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener noreferrer" aria-label="Sign up at Ko‑fi">
-                    <span>Sign Up at Ko‑fi — $24/mo</span>
-                </a>
-                <a class="btn btn-secondary" href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener noreferrer" aria-label="Join the Discord">
-                    <span>Join the Discord (Free)</span>
-                </a>
-            </div>
+            <img src="images/mics/mic-gold.png" alt="" class="mic mic-gold" aria-hidden="true" />
+            <img src="images/mics/pink-mic.png" alt="" class="mic mic-pink" aria-hidden="true" />
+            <img src="images/mics/mic-turqoise.png" alt="" class="mic mic-turqoise" aria-hidden="true" />
+            <img src="images/mics/mic-purple.png" alt="" class="mic mic-purple" aria-hidden="true" />
 
-            <div class="grid" style="margin-top:32px">
-                <div class="card" aria-labelledby="whatis">
-                    <h3 id="whatis">What is Endless Vocals?</h3>
-                    <p>It’s a modern, no‑hype training space for singers. We keep what works, focus on repeatable habits, and measure progress by what you can feel and perform—on stage and in the studio.</p>
-                    <div class="list" aria-label="Highlights">
-                        <div class="item">Two‑Month Bootcamps with Ryan or Tiago</div>
-                        <div class="item">Live sessions + replays you can follow</div>
-                        <div class="item">Free Discord for clips, feedback, and community</div>
-                    </div>
-                    <p class="note" style="margin-top:10px">Start in November. Join now to get the prep checklist before the first session.</p>
+            <div class="hero-content">
+                <h1 id="h1" class="title">Your Vocals Don’t Expire</h1>
+                <p class="subtitle">Practical training, clear structure, steady progress. Two‑month bootcamps with Ryan Wall and Tiago Costa. Live sessions, replays, and a friendly Discord to keep you moving.</p>
+                <div class="cta-row" role="group" aria-label="Primary actions">
+                    <a class="btn btn-primary" href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener noreferrer" aria-label="Sign up at Ko‑fi">
+                        <span>Sign Up at Ko‑fi — $24/mo</span>
+                    </a>
+                    <a class="btn btn-secondary" href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener noreferrer" aria-label="Join the Discord">
+                        <span>Join the Discord (Free)</span>
+                    </a>
+                    <a class="btn btn-ghost" href="#coaches" aria-label="Meet the Endless Vocals coaches">
+                        <span>Meet the Coaches</span>
+                    </a>
                 </div>
-                <div class="card" aria-labelledby="about">
-                    <h3 id="about">Why a new school?</h3>
-                    <p><strong>Vendera Vocal Academy has sadly come to a close.</strong> Jaime graciously encouraged us to continue helping singers in a new format. Endless Vocals is our way forward—built with care by Ryan Wall and Tiago Costa.</p>
-                    <p class="note">“Jaime has given us his full blessing to continue teaching his ISO Method to help singers raise their voice in a different format.”</p>
-                    <div style="margin-top:8px">
-                        <span class="pill">Live • Practical • Friendly</span>
-                        <span class="pill">Start/Stop Anytime</span>
-                        <span class="pill">Beginner → Pro</span>
+
+                <div class="grid" style="margin-top:32px">
+                    <div class="card" aria-labelledby="whatis">
+                        <h3 id="whatis">What is Endless Vocals?</h3>
+                        <p>It’s a modern, no‑hype training space for singers. We keep what works, focus on repeatable habits, and measure progress by what you can feel and perform—on stage and in the studio.</p>
+                        <div class="list" aria-label="Highlights">
+                            <div class="item">Two‑Month Bootcamps with Ryan or Tiago</div>
+                            <div class="item">Live sessions + replays you can follow</div>
+                            <div class="item">Free Discord for clips, feedback, and community</div>
+                        </div>
+                        <p class="note" style="margin-top:10px">Start in November. Join now to get the prep checklist before the first session.</p>
+                    </div>
+                    <div class="card" aria-labelledby="about">
+                        <h3 id="about">Why a new school?</h3>
+                        <p><strong>Vendera Vocal Academy has sadly come to a close.</strong> Jaime graciously encouraged us to continue helping singers in a new format. Endless Vocals is our way forward—built with care by Ryan Wall and Tiago Costa.</p>
+                        <p class="note">“Jaime has given us his full blessing to continue teaching his ISO Method to help singers raise their voice in a different format.”</p>
+                        <div style="margin-top:8px">
+                            <span class="pill">Live • Practical • Friendly</span>
+                            <span class="pill">Start/Stop Anytime</span>
+                            <span class="pill">Beginner → Pro</span>
+                        </div>
                     </div>
                 </div>
+
+                <div class="divider"></div>
+
+                <section class="card" aria-labelledby="how">
+                    <h3 id="how">How it works</h3>
+                    <ol>
+                        <li style="margin:8px 0">Join the <a href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener">Discord</a> (free) to see schedules, share clips, and meet the community.</li>
+                        <li style="margin:8px 0">When you’re ready, enroll in a <a href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener">Two‑Month Bootcamp</a> ($24/month via Ko‑fi). Attend live or watch replays—your pace.</li>
+                        <li style="margin:8px 0">Follow the weekly checklist. Short, repeatable sessions beat long, rare ones.</li>
+                    </ol>
+                </section>
             </div>
+        </section>
 
-            <div class="divider"></div>
-
-            <section class="card" aria-labelledby="how">
-                <h3 id="how">How it works</h3>
-                <ol>
-                    <li style="margin:8px 0">Join the <a href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener">Discord</a> (free) to see schedules, share clips, and meet the community.</li>
-                    <li style="margin:8px 0">When you’re ready, enroll in a <a href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener">Two‑Month Bootcamp</a> ($24/month via Ko‑fi). Attend live or watch replays—your pace.</li>
-                    <li style="margin:8px 0">Follow the weekly checklist. Short, repeatable sessions beat long, rare ones.</li>
-                </ol>
-            </section>
+        <section class="coaches" id="coaches" aria-labelledby="coach-title">
+            <h2 id="coach-title">Meet the Coaches</h2>
+            <p class="lead">Endless Vocals is powered by working vocalists who teach from the stage, the studio, and years of mentoring singers across genres. Meet the team guiding every session.</p>
+            <div class="coach-grid">
+                <article class="coach-card" aria-labelledby="coach-ryan">
+                    <h3 id="coach-ryan">Ryan Wall</h3>
+                    <span class="role">Head Coach &amp; Founder</span>
+                    <p>Ryan Wall is a singer, songwriter, and long-time vocal coach who spent a decade teaching alongside Jaime Vendera as Chief Coach of the Vendera Vocal Academy. With over 20 years of songwriting experience and multiple albums to his name, Ryan brings a deep creative perspective to his teaching. Through Endless Vocals, he not only helps singers strengthen and protect their voices but also guides them in the art of writing and producing original music—skills he shares directly with members of the Discord community. His coaching blends technical precision, stage experience, and creative mentorship to help every vocalist find their unique voice and message.</p>
+                    <figure>
+                        <img src="images/coaches/ryan-wall.svg" alt="Stylized illustration of Ryan Wall" loading="lazy" decoding="async">
+                    </figure>
+                    <img src="images/mics/mic-gold.png" alt="" class="mic-deco" aria-hidden="true">
+                </article>
+                <article class="coach-card" aria-labelledby="coach-tiago">
+                    <h3 id="coach-tiago">Tiago Costa</h3>
+                    <span class="role">Coach &amp; Artist</span>
+                    <p>Tiago Costa is a dynamic vocalist, guitarist, and multi-instrumentalist known for his work with Firemage and Xeque Mate. His background spans rock, metal, and folk metal, giving him a broad stylistic reach and deep stage experience. Within Endless Vocals, Tiago focuses on expression, authenticity, and turning raw technique into art. His guitar and musicianship training will also play a role in future bootcamps, connecting vocal control with instrumental understanding. Tiago’s goal is to help singers develop tone, emotion, and confidence—on stage, in the studio, and in themselves.</p>
+                    <figure>
+                        <img src="images/coaches/tiago-costa.svg" alt="Stylized illustration of Tiago Costa" loading="lazy" decoding="async">
+                    </figure>
+                    <img src="images/mics/mic-turqoise.png" alt="" class="mic-deco" aria-hidden="true">
+                </article>
+                <article class="coach-card mentor" aria-labelledby="coach-jaime">
+                    <h3 id="coach-jaime">Jaime Vendera</h3>
+                    <span class="role">Mentor &amp; Originator of the ISO Method</span>
+                    <p>Jaime Vendera is an internationally recognized vocal coach, author of <em>Raise Your Voice</em>, and creator of the ISO Method. He has trained countless singers and professionals around the world, known for his legendary glass-shattering demonstrations and focus on vocal health. Though VVA has come to a close, Jaime continues to inspire and mentor Ryan and Tiago, giving Endless Vocals his full blessing to carry the ISO legacy forward. While Jaime isn't directly involved in Endless Vocals, his website is worth mentioning as it's a bastion for singers. <a href="https://www.jaimevendera.com" target="_blank" rel="noopener">www.jaimevendera.com</a></p>
+                    <figure>
+                        <img src="images/coaches/jaime-vendera.svg" alt="Stylized illustration of Jaime Vendera" loading="lazy" decoding="async">
+                    </figure>
+                    <img src="images/mics/mic-purple.png" alt="" class="mic-deco" aria-hidden="true">
+                </article>
+            </div>
         </section>
 
         <footer class="footer" aria-label="Site footer">


### PR DESCRIPTION
## Summary
- add a navigation link and hero CTA that smooth-scroll to the new Meet the Coaches section
- decorate the hero with microphone artwork and wrap content to keep the layout intact
- introduce a full coaches section with bios, stylized portrait SVGs, and a mentor callout for Jaime Vendera

## Testing
- Manual: Viewed `index.html` in a browser via `python3 -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68e5c78adce88331bf4f52140bd48be6