### PR TITLE
Clarify Ko-fi messaging and adjust mobile coaches layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Endless Vocals — Your Vocals Don’t Expire</title>
-    <meta name="description" content="Endless Vocals is a practical, modern vocal school by Ryan Wall and Tiago Costa. Two‑month bootcamps, live sessions + replays, and a free Discord community." />
+    <meta name="description" content="Endless Vocals is a practical, modern vocal school by Ryan Wall and Tiago Costa. Rotating live bootcamps, on-demand replays, and a free Discord community to keep you on track." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
@@ -356,9 +356,9 @@
             }
 
             .coaches {
-                border-radius: 0;
+                border-radius: 18px;
                 padding: 40px 24px 48px;
-                margin: 48px -24px 0;
+                margin: 48px 24px 0;
             }
 
             .coach-grid {
@@ -416,13 +416,13 @@
                 <nav aria-label="Site navigation">
                     <a href="#coaches">Meet the Coaches</a>
                 </nav>
-                <div class="badge">Two‑Month Bootcamps • Free Discord</div>
+                <div class="badge">Rotating Bootcamps • Free Discord</div>
             </div>
         </header>
 
         <section class="hero" aria-labelledby="h1">
             <h1 id="h1" class="title">Your Vocals Don’t Expire</h1>
-            <p class="subtitle">Practical training, clear structure, steady progress. Two‑month bootcamps with Ryan Wall and Tiago Costa. Live sessions, replays, and a friendly Discord to keep you moving.</p>
+            <p class="subtitle">Practical training, clear structure, steady progress. Your Ko‑fi membership unlocks rotating bootcamps with Ryan Wall and Tiago Costa, live sessions, replays, and a friendly Discord to keep you moving.</p>
             <div class="cta-row" role="group" aria-label="Primary actions">
                 <a class="btn btn-primary" href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener noreferrer" aria-label="Sign up at Ko‑fi">
                     <span>Sign Up at Ko‑fi — $24/mo</span>
@@ -437,7 +437,7 @@
                     <h3 id="whatis">What is Endless Vocals?</h3>
                     <p>It’s a modern, no‑hype training space for singers. We keep what works, focus on repeatable habits, and measure progress by what you can feel and perform—on stage and in the studio.</p>
                     <div class="list" aria-label="Highlights">
-                        <div class="item">Two‑Month Bootcamps with Ryan or Tiago</div>
+                        <div class="item">Rotating bootcamps with Ryan and Tiago</div>
                         <div class="item">Live sessions + replays you can follow</div>
                         <div class="item">Free Discord for clips, feedback, and community</div>
                     </div>
@@ -461,7 +461,7 @@
                 <h3 id="how">How it works</h3>
                 <ol>
                     <li style="margin:8px 0">Join the <a href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener">Discord</a> (free) to see schedules, share clips, and meet the community.</li>
-                    <li style="margin:8px 0">When you’re ready, enroll in a <a href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener">Two‑Month Bootcamp</a> ($24/month via Ko‑fi). Attend live or watch replays—your pace.</li>
+                    <li style="margin:8px 0">When you’re ready, enroll in a <a href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener">paid tier</a> ($24/month via Ko‑fi) where you can attend bootcamps curated by Ryan and Tiago, access course materials, replays, and direct support from the coaches—all at your own pace.</li>
                     <li style="margin:8px 0">Follow the weekly checklist. Short, repeatable sessions beat long, rare ones.</li>
                 </ol>
             </section>


### PR DESCRIPTION
## Summary
- clarify marketing copy to explain the rotating Ko-fi bootcamp membership instead of fixed two-month cohorts
- update the “How it works” paid tier step with the new description provided by the team
- adjust the mobile layout so the “Meet the Coaches” section is centered with comfortable margins

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e6d26807cc8331a47a987324bcfdad