### PR TITLE
Revamp homepage theme and content

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,37 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
     <style>
         :root {
+            --bg: #f4f7ff;
+            --fg: #0d1a33;
+            --muted: #3f4c66;
+            --accent: #0d63d7;
+            --accent-2: #ff76b5;
+            --accent-3: #d9e6ff;
+            --card-bg: #ffffff;
+            --card-border: #d4ddf0;
+            --shadow: 0 20px 60px rgba(13, 36, 88, 0.18);
+            --hero-gradient: radial-gradient(1200px 600px at 10% -10%, rgba(13, 99, 215, .25), transparent 60%), radial-gradient(800px 500px at 100% 0%, rgba(255, 118, 181, .25), transparent 60%), linear-gradient(135deg, #fdfdff, #e9f1ff 60%, #f1f5ff 100%);
+            --hero-border: rgba(13, 99, 215, .18);
+            --hero-highlight: rgba(13, 99, 215, .08);
+            --pill-border: #c5d4f2;
+            --sticky-bg: linear-gradient(180deg, rgba(244, 247, 255, 0), rgba(244, 247, 255, .9) 30%, rgba(244, 247, 255, .98));
+        }
+
+        body[data-theme="dark"] {
             --bg: #0b0b0c;
             --fg: #f5f2ed;
             --muted: #bdb9b2;
             --accent: #16a6a3;
             --accent-2: #f08dbb;
             --accent-3: #2c1e4a;
+            --card-bg: #121217;
+            --card-border: #26262f;
+            --shadow: 0 20px 60px rgba(0, 0, 0, .35);
+            --hero-gradient: radial-gradient(1200px 600px at 10% -10%, rgba(22, 166, 163, .4), transparent 60%), radial-gradient(800px 500px at 100% 0%, rgba(240, 141, 187, .28), transparent 60%), linear-gradient(135deg, #191a1d, #0d0d12 60%, #15121c 100%);
+            --hero-border: rgba(240, 141, 187, .24);
+            --hero-highlight: rgba(22, 166, 163, .12);
+            --pill-border: #2c2c33;
+            --sticky-bg: linear-gradient(180deg, rgba(10, 10, 12, 0), rgba(10, 10, 12, .8) 30%, rgba(10, 10, 12, .95));
         }
 
         * {
@@ -46,8 +71,9 @@
             overflow: hidden;
             border-radius: 24px;
             padding: 60px 24px;
-            background: radial-gradient(1200px 600px at 10% -10%, rgba(22,166,163,.4), transparent 60%), radial-gradient(800px 500px at 100% 0%, rgba(240,141,187,.28), transparent 60%), linear-gradient(135deg, #191a1d, #0d0d12 60%, #15121c 100%);
-            box-shadow: 0 20px 60px rgba(0,0,0,.35);
+            background: var(--hero-gradient);
+            box-shadow: var(--shadow);
+            border: 1px solid var(--hero-border);
         }
 
         .masthead {
@@ -64,10 +90,44 @@
             font-size: 28px
         }
 
-        .badge {
+        .mode-toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
             font-size: 14px;
-            color: var(--muted)
+            color: var(--muted);
+            background: var(--hero-highlight);
+            border: 1px solid var(--hero-border);
+            border-radius: 999px;
+            padding: 6px 14px;
+            box-shadow: var(--shadow);
         }
+
+            .mode-toggle button {
+                appearance: none;
+                border: none;
+                background: var(--accent);
+                color: #fff;
+                font-weight: 600;
+                border-radius: 999px;
+                padding: 6px 14px;
+                cursor: pointer;
+                transition: transform .2s ease;
+            }
+
+            body[data-theme="dark"] .mode-toggle button {
+                color: #041313;
+                background: linear-gradient(135deg, var(--accent), #1bc7c3);
+            }
+
+            .mode-toggle button:focus-visible {
+                outline: 2px solid var(--accent-2);
+                outline-offset: 2px;
+            }
+
+            .mode-toggle button:hover {
+                transform: translateY(-1px);
+            }
 
         .title {
             font-size: clamp(36px, 4.5vw, 72px);
@@ -98,7 +158,7 @@
             padding: 16px 22px;
             font-weight: 700;
             letter-spacing: .3px;
-            box-shadow: 0 6px 18px rgba(0,0,0,.35)
+            box-shadow: 0 6px 18px rgba(13, 36, 88, .15)
         }
 
         .btn-primary {
@@ -109,6 +169,10 @@
         .btn-secondary {
             background: linear-gradient(135deg, var(--accent-2), #ffb0cf);
             color: #2d0f20
+        }
+
+        body[data-theme="dark"] .btn {
+            box-shadow: 0 6px 18px rgba(0,0,0,.35);
         }
 
         .btn:focus {
@@ -124,8 +188,8 @@
         }
 
         .card {
-            background: #121217;
-            border: 1px solid #26262f;
+            background: var(--card-bg);
+            border: 1px solid var(--card-border);
             border-radius: 18px;
             padding: 22px
         }
@@ -136,12 +200,12 @@
 
         .divider {
             height: 1px;
-            background: #22242a;
+            background: var(--card-border);
             margin: 40px 0
         }
 
         .footer {
-            color: #9a9791;
+            color: var(--muted);
             font-size: 14px;
             text-align: center;
             margin: 32px 0
@@ -150,9 +214,9 @@
         .pill {
             display: inline-block;
             padding: 6px 10px;
-            border: 1px solid #2c2c33;
+            border: 1px solid var(--pill-border);
             border-radius: 999px;
-            color: #bdb9b2;
+            color: var(--muted);
             font-size: 12px;
             margin-right: 8px
         }
@@ -165,18 +229,42 @@
         }
 
             .list .item {
-                background: #14141b;
-                border: 1px solid #262631;
+                background: var(--hero-highlight);
+                border: 1px solid var(--card-border);
                 border-radius: 12px;
                 padding: 12px;
                 font-size: 14px;
-                color: #cbc7c0
+                color: var(--fg)
             }
 
         .note {
             font-size: 13px;
-            color: #bdb9b2
+            color: var(--muted)
         }
+
+        .coach-grid {
+            display: grid;
+            gap: 24px;
+        }
+
+        @media (min-width: 880px) {
+            .coach-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+        }
+
+        .coach {
+            background: var(--hero-highlight);
+            border: 1px solid var(--card-border);
+            border-radius: 16px;
+            padding: 18px;
+            box-shadow: var(--shadow);
+        }
+
+            .coach h3 {
+                margin-top: 0;
+                margin-bottom: 12px;
+            }
 
         @media (max-width: 880px) {
             .grid {
@@ -189,7 +277,7 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: linear-gradient(180deg, rgba(10,10,12,.0), rgba(10,10,12,.8) 30%, rgba(10,10,12,.95));
+            background: var(--sticky-bg);
             padding: 12px 16px;
             backdrop-filter: blur(6px);
         }
@@ -208,11 +296,14 @@
         }
     </style>
 </head>
-<body>
+<body data-theme="light">
     <div class="container">
         <header class="masthead" aria-label="Site header">
             <div class="logo" aria-label="Endless Vocals">ENDLESS <span style="opacity:.7;font-weight:600">vocals</span></div>
-            <div class="badge">Two‑Month Bootcamps • Free Discord</div>
+            <div class="mode-toggle" aria-live="polite">
+                <span id="mode-label">Light mode</span>
+                <button id="mode-button" type="button" aria-pressed="false" aria-label="Switch to dark mode">Switch to Dark</button>
+            </div>
         </header>
 
         <section class="hero" aria-labelledby="h1">
@@ -230,13 +321,14 @@
             <div class="grid" style="margin-top:32px">
                 <div class="card" aria-labelledby="whatis">
                     <h3 id="whatis">What is Endless Vocals?</h3>
-                    <p>It’s a modern, no‑hype training space for singers. We keep what works, focus on repeatable habits, and measure progress by what you can feel and perform—on stage and in the studio.</p>
+                    <p>It’s a modern training space for singers who want to get straight to the point about improving their singing skill. We keep what works, focus on repeatable habits, and measure progress by what you can feel and perform—on stage and in the studio.</p>
                     <div class="list" aria-label="Highlights">
                         <div class="item">Two‑Month Bootcamps with Ryan or Tiago</div>
                         <div class="item">Live sessions + replays you can follow</div>
                         <div class="item">Free Discord for clips, feedback, and community</div>
                     </div>
-                    <p class="note" style="margin-top:10px">Start in November. Join now to get the prep checklist before the first session.</p>
+                    <p style="margin-top:12px">Learn how to create your own songs from scratch, get comfortable recording inside a DAW, and strengthen your lyric writing so every performance tells a story.</p>
+                    <p class="note" style="margin-top:10px">First bootcamp starts in December and will be hosted by Coach Ryan. Join now to get the prep checklist before the first session. After Ryan's bootcamp, it will be Coach Tiago's Class for 2 months, and the cycle repeats. Stay in the school for consistent vocal training!</p>
                 </div>
                 <div class="card" aria-labelledby="about">
                     <h3 id="about">Why a new school?</h3>
@@ -262,6 +354,23 @@
             </section>
         </section>
 
+        <section class="card" aria-labelledby="coaches" style="margin-top:32px">
+            <h2 id="coaches" style="margin-bottom:18px">Meet the Coaches</h2>
+            <p class="note" style="margin-bottom:22px">The Endless Vocals team blends decades of stage experience, technical mastery, and songwriting craft to help you grow as a vocalist and artist. Get to know the coaches guiding each session and the mentor who set the foundations.</p>
+            <div class="coach-grid">
+                <article class="coach" aria-labelledby="ryan-name">
+                    <h3 id="ryan-name">Head Coach &amp; Founder — Ryan Wall</h3>
+                    <p>Ryan Wall is a singer, songwriter, and long-time vocal coach who spent a decade teaching alongside Jaime Vendera as his right-hand coach at the Vendera Vocal Academy. With over 20 years of songwriting experience and multiple albums to his name, Ryan brings a deep creative perspective to his teaching.</p>
+                    <p>Through Endless Vocals, he not only helps singers strengthen and protect their voices but also guides them in the art of writing and producing original music—skills he shares directly with members of the Discord community. His coaching blends technical precision, stage experience, and creative mentorship to help every vocalist find their unique voice and message.</p>
+                </article>
+                <article class="coach" aria-labelledby="tiago-name">
+                    <h3 id="tiago-name">Coach — Tiago Costa</h3>
+                    <p>Tiago Costa is a dynamic vocalist, guitarist, and multi-instrumentalist known for his work with Firemage and Xeque Mate. A primary coach at Vendera Vocal Academy, his clinics and hangouts became essential resources for singers hungry to grow.</p>
+                    <p>Tiago’s background spans rock, metal, and folk metal, giving him a broad stylistic reach and deep stage experience. Within Endless Vocals, he focuses on expression, authenticity, and turning raw technique into art. His guitar and musicianship training will also play a role in future bootcamps, connecting vocal control with instrumental understanding. Tiago’s goal is to help singers develop tone, emotion, and confidence—on stage, in the studio, and in themselves.</p>
+                </article>
+            </div>
+        </section>
+
         <footer class="footer" aria-label="Site footer">
             © <span id="year"></span> Endless Vocals. All rights reserved.
         </footer>
@@ -276,7 +385,33 @@
     </div>
 
     <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
+    const yearEl = document.getElementById('year');
+    yearEl.textContent = new Date().getFullYear();
+
+    const body = document.body;
+    const modeLabel = document.getElementById('mode-label');
+    const modeButton = document.getElementById('mode-button');
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const storedTheme = localStorage.getItem('ev-theme');
+
+    const initialTheme = storedTheme ? storedTheme : (prefersDark ? 'dark' : 'light');
+
+    function applyTheme(theme) {
+        body.dataset.theme = theme;
+        const nextTheme = theme === 'dark' ? 'light' : 'dark';
+        modeLabel.textContent = `${theme.charAt(0).toUpperCase()}${theme.slice(1)} mode`;
+        modeButton.textContent = `Switch to ${nextTheme.charAt(0).toUpperCase()}${nextTheme.slice(1)}`;
+        modeButton.setAttribute('aria-pressed', theme === 'dark');
+        modeButton.setAttribute('aria-label', `Switch to ${nextTheme} mode`);
+        localStorage.setItem('ev-theme', theme);
+    }
+
+    applyTheme(initialTheme);
+
+    modeButton.addEventListener('click', () => {
+        const newTheme = body.dataset.theme === 'dark' ? 'light' : 'dark';
+        applyTheme(newTheme);
+    });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh the homepage with a bright light-mode palette inspired by classic social colors while preserving the existing dark palette
- add a persistent light/dark mode toggle to the header with saved preferences and responsive styles
- update hero copy, scheduling details, and introduce a new "Meet the Coaches" section highlighting Ryan and Tiago

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ff11091ccc8331a9515ad2272f5b2a