### PR TITLE
Add FAQ page with onboarding instructions

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Endless Vocals — Frequently Asked Questions</title>
+    <meta name="description" content="Answers to common questions about Endless Vocals, including how to join Discord, connect Ko-fi, and participate in bootcamps." />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f6f9ff;
+            --fg: #0c182b;
+            --muted: #50627a;
+            --surface: rgba(255, 255, 255, 0.94);
+            --surface-strong: #ffffff;
+            --surface-border: rgba(37, 74, 140, 0.18);
+            --surface-soft: rgba(246, 249, 255, 0.9);
+            --accent: #1f5cff;
+            --accent-2: #ff7a1a;
+            --accent-3: #0f2c7a;
+            --accent-alt: #5f89ff;
+            --accent-2-alt: #ffd08f;
+            --shadow: rgba(15, 51, 120, 0.12);
+            --hero-bg: radial-gradient(1200px 600px at 10% -10%, rgba(31,92,255,.18), transparent 60%), radial-gradient(900px 600px at 100% 0%, rgba(255,122,26,.15), transparent 60%), linear-gradient(135deg, #fdfcff, #f0f5ff 60%, #f9fbff 100%);
+            --section-bg: rgba(255,255,255,0.82);
+            --focus-outline: rgba(31,92,255,.28);
+        }
+
+        body[data-theme="dark"] {
+            color-scheme: dark;
+            --bg: #0b0b0c;
+            --fg: #f5f2ed;
+            --muted: #bdb9b2;
+            --surface: rgba(12, 12, 16, 0.92);
+            --surface-strong: #121217;
+            --surface-border: #26262f;
+            --surface-soft: rgba(20, 20, 27, 0.9);
+            --accent: #16a6a3;
+            --accent-2: #f08dbb;
+            --accent-3: #2c1e4a;
+            --accent-alt: #1bc7c3;
+            --accent-2-alt: #ffb0cf;
+            --shadow: rgba(0, 0, 0, 0.35);
+            --hero-bg: radial-gradient(1200px 600px at 10% -10%, rgba(22,166,163,.4), transparent 60%), radial-gradient(800px 500px at 100% 0%, rgba(240,141,187,.28), transparent 60%), linear-gradient(135deg, #191a1d, #0d0d12 60%, #15121c 100%);
+            --section-bg: #14141b;
+            --focus-outline: rgba(255,255,255,.2);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html, body {
+            margin: 0;
+            padding: 0;
+            background: var(--bg);
+            color: var(--fg);
+            font-family: Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif;
+            scroll-behavior: smooth;
+            transition: background .3s ease, color .3s ease;
+        }
+
+        a {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        .container {
+            max-width: 860px;
+            margin: 0 auto;
+            padding: 32px 20px 80px;
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 20px;
+            margin-bottom: 32px;
+        }
+
+        .logo {
+            font-weight: 800;
+            letter-spacing: 2px;
+            font-size: 24px;
+        }
+
+        nav {
+            display: flex;
+            gap: 14px;
+            font-size: 15px;
+            font-weight: 600;
+            flex-wrap: wrap;
+        }
+
+            nav a {
+                padding: 10px 16px;
+                border-radius: 999px;
+                border: 1px solid transparent;
+                color: var(--muted);
+                transition: border .2s ease, color .2s ease, background .2s ease;
+            }
+
+            nav a:hover,
+            nav a:focus,
+            nav a[aria-current="page"] {
+                color: var(--fg);
+                background: var(--surface-soft);
+                border-color: var(--surface-border);
+            }
+
+        .hero {
+            background: var(--hero-bg);
+            border-radius: 24px;
+            padding: 40px 28px;
+            box-shadow: 0 20px 60px var(--shadow);
+            margin-bottom: 40px;
+        }
+
+        .hero h1 {
+            font-size: clamp(32px, 5vw, 46px);
+            margin-bottom: 12px;
+        }
+
+        .hero p {
+            font-size: 18px;
+            line-height: 1.6;
+            color: var(--muted);
+            max-width: 560px;
+        }
+
+        .faq-section {
+            display: grid;
+            gap: 18px;
+        }
+
+        .faq-item {
+            background: var(--section-bg);
+            border: 1px solid var(--surface-border);
+            border-radius: 18px;
+            padding: 24px;
+            box-shadow: 0 12px 30px var(--shadow);
+        }
+
+        .faq-item h2 {
+            margin: 0 0 12px;
+            font-size: 20px;
+        }
+
+        .faq-item p,
+        .faq-item ol,
+        .faq-item ul {
+            margin: 0;
+            font-size: 16px;
+            line-height: 1.7;
+            color: var(--muted);
+        }
+
+        .faq-item + .faq-item {
+            margin-top: 6px;
+        }
+
+        .faq-item ol,
+        .faq-item ul {
+            padding-left: 20px;
+        }
+
+        .faq-item li {
+            margin-bottom: 8px;
+        }
+
+        .note {
+            margin-top: 16px;
+            padding: 14px 16px;
+            border-radius: 14px;
+            background: var(--surface-soft);
+            border: 1px solid var(--surface-border);
+            color: var(--fg);
+            font-weight: 600;
+        }
+
+        footer {
+            margin-top: 64px;
+            font-size: 14px;
+            color: var(--muted);
+            text-align: center;
+        }
+
+        @media (max-width: 600px) {
+            header {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .hero {
+                padding: 32px 20px;
+            }
+        }
+    </style>
+</head>
+<body data-theme="light">
+    <div class="container">
+        <header aria-label="Site header">
+            <div class="logo">ENDLESS <span style="opacity:.7;font-weight:600">vocals</span></div>
+            <nav aria-label="Site navigation">
+                <a href="index.html">Home</a>
+                <a href="faq.html" aria-current="page">FAQ</a>
+                <a href="index.html#coaches">Meet the Coaches</a>
+            </nav>
+        </header>
+
+        <section class="hero" aria-labelledby="faq-title">
+            <h1 id="faq-title">Frequently Asked Questions</h1>
+            <p>Everything you need to know to get started with Endless Vocals—from joining our community to making the most of bootcamps and coaching.</p>
+        </section>
+
+        <section class="faq-section" aria-label="Common questions and answers">
+            <article class="faq-item" aria-labelledby="getting-started">
+                <h2 id="getting-started">How do I join Endless Vocals?</h2>
+                <ol>
+                    <li>Create a free Discord account so you can join our community server.</li>
+                    <li>Set up a Ko-fi account using the same email you plan to use for Discord.</li>
+                    <li>Connect your Discord account to your Ko-fi profile under <strong>Settings &gt; Connections</strong>. This link is required so Ko-fi can automatically grant you the subscriber role on Discord.</li>
+                    <li>Join the <a href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener">Endless Vocals Discord server</a>.</li>
+                    <li>Subscribe to the <a href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener">Endless Vocals Ko-fi membership</a> to access live bootcamps and replays.</li>
+                </ol>
+                <p class="note">You must complete the Discord → Ko-fi connection before subscribing; otherwise Ko-fi cannot give you access to the member-only Discord channels.</p>
+            </article>
+
+            <article class="faq-item" aria-labelledby="discord-question">
+                <h2 id="discord-question">What happens after I connect Discord and Ko-fi?</h2>
+                <p>Once Ko-fi detects your Discord account, the system automatically assigns you the correct roles when your membership is active. Within a few minutes, new private channels will appear where we host bootcamp materials, schedules, and replays. If you don&apos;t see the new channels after 15 minutes, disconnect and reconnect the integration from Ko-fi, then rejoin the Discord server.</p>
+            </article>
+
+            <article class="faq-item" aria-labelledby="bootcamp-format">
+                <h2 id="bootcamp-format">What do the two-month bootcamps include?</h2>
+                <ul>
+                    <li>Weekly live coaching calls led by Ryan or Tiago (attend live or catch the replay).</li>
+                    <li>Step-by-step checklists to keep your practice sessions short and consistent.</li>
+                    <li>Feedback threads inside Discord where you can post clips for review.</li>
+                    <li>Songwriting, lyric, and DAW mini-lessons woven through the curriculum.</li>
+                </ul>
+            </article>
+
+            <article class="faq-item" aria-labelledby="pricing">
+                <h2 id="pricing">How much does it cost?</h2>
+                <p>Bootcamp access is $24 per month through Ko-fi. The Discord community is free—only the bootcamp membership requires payment. You can start and stop your membership whenever you need.</p>
+            </article>
+
+            <article class="faq-item" aria-labelledby="support">
+                <h2 id="support">Who do I contact if I have issues?</h2>
+                <p>Reach out inside the Discord server by tagging <strong>@Coach Ryan</strong> or <strong>@Coach Tiago</strong>, or send us a direct message on Ko-fi. We monitor both platforms and will help you get connected.</p>
+            </article>
+        </section>
+
+        <footer aria-label="Site footer">
+            © <span id="year"></span> Endless Vocals. All rights reserved.
+        </footer>
+    </div>
+
+    <script>
+    const body = document.body;
+    const yearEl = document.getElementById('year');
+    if (yearEl) {
+        yearEl.textContent = new Date().getFullYear();
+    }
+
+    const savedTheme = (() => {
+        try {
+            return localStorage.getItem('ev-theme');
+        } catch (err) {
+            return null;
+        }
+    })();
+
+    if (savedTheme) {
+        body.dataset.theme = savedTheme;
+    }
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -585,6 +585,7 @@
             <div class="logo" aria-label="Endless Vocals">ENDLESS <span style="opacity:.7;font-weight:600">vocals</span></div>
             <div class="masthead-right">
                 <nav aria-label="Site navigation">
+                    <a href="faq.html">FAQ</a>
                     <a href="#coaches">Meet the Coaches</a>
                 </nav>
                 <button id="theme-toggle" class="mode-toggle" type="button" aria-label="Switch to dark mode">


### PR DESCRIPTION
## Summary
- add a dedicated FAQ page that answers common onboarding questions
- include clear steps for creating Discord and Ko-fi accounts and connecting them
- link the existing homepage navigation to the new FAQ resource

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69012da7a69483318c22a4c8dfb2e328