### PR TITLE
Move promo video into hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
         }
 
         .video-section {
-            margin: 64px 0 32px;
+            margin: 28px 0 32px;
         }
 
         .video-card {
@@ -617,6 +617,23 @@
                 </a>
             </div>
 
+            <section class="video-section" aria-labelledby="video-title">
+                <div class="card video-card">
+                    <h2 id="video-title">Inside Endless Vocals</h2>
+                    <p>Take a look at how we run bootcamps, build vocal habits, and support each other inside the community. Hear
+                        directly from Coach Ryan about how the program unfolds.</p>
+                    <div class="video-frame">
+                        <iframe id="bootcamp-video" src="https://www.youtube-nocookie.com/embed/B0QLk8mLWQE?rel=0"
+                            title="Inside Endless Vocals" loading="lazy"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                    </div>
+                    <a class="video-watch" href="https://www.youtube.com/watch?v=B0QLk8mLWQE" target="_blank" rel="noopener">
+                        Watch it on YouTube
+                    </a>
+                </div>
+            </section>
+
             <div class="grid" style="margin-top:32px">
                 <div class="card" aria-labelledby="whatis">
                     <h3 id="whatis">What is Endless Vocals?</h3>
@@ -657,23 +674,6 @@
                 <img src="images/mics/mic-purple.png" alt="" loading="lazy">
                 <img src="images/mics/mic-turqoise.png" alt="" loading="lazy">
                 <img src="images/mics/pink-mic.png" alt="" loading="lazy">
-            </div>
-        </section>
-
-        <section class="video-section" aria-labelledby="video-title">
-            <div class="card video-card">
-                <h2 id="video-title">Inside Endless Vocals</h2>
-                <p>Take a look at how we run bootcamps, build vocal habits, and support each other inside the community. Hear
-                    directly from Coach Ryan about how the program unfolds.</p>
-                <div class="video-frame">
-                    <iframe id="bootcamp-video" src="https://www.youtube-nocookie.com/embed/B0QLk8mLWQE?rel=0"
-                        title="Inside Endless Vocals" loading="lazy"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-                </div>
-                <a class="video-watch" href="https://www.youtube.com/watch?v=B0QLk8mLWQE" target="_blank" rel="noopener">
-                    Watch it on YouTube
-                </a>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- move the Inside Endless Vocals video into the hero beneath the main headline so it appears near the top of the page
- adjust the video section spacing to fit the hero layout

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfe5d23408331834aa9bc75f355ef)