### PR TITLE
Move promo video into hero section and add back-to-top button

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
         }
 
         .video-section {
-            margin: 64px 0 32px;
+            margin: 28px 0 32px;
         }
 
         .video-card {
@@ -430,6 +430,35 @@
             margin: 32px 0
         }
 
+        .back-to-top-wrap {
+            display: flex;
+            justify-content: center;
+            margin: 12px 0 48px;
+        }
+
+        .back-to-top {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 12px 18px;
+            border-radius: 14px;
+            background: var(--surface);
+            border: 1px solid var(--surface-border);
+            color: var(--fg);
+            font-weight: 700;
+            letter-spacing: .2px;
+            box-shadow: 0 10px 24px var(--shadow);
+            transition: transform .2s ease, box-shadow .2s ease, background .2s ease;
+        }
+
+        .back-to-top:hover,
+        .back-to-top:focus {
+            outline: none;
+            background: var(--surface-strong);
+            transform: translateY(-1px);
+            box-shadow: 0 14px 28px var(--shadow);
+        }
+
         .pill {
             display: inline-block;
             padding: 6px 10px;
@@ -589,7 +618,7 @@
         }
     </style>
 </head>
-<body data-theme="light">
+<body id="top" data-theme="light">
     <div class="container">
         <header class="masthead" aria-label="Site header">
             <div class="logo" aria-label="Endless Vocals">ENDLESS <span style="opacity:.7;font-weight:600">vocals</span></div>
@@ -616,6 +645,23 @@
                     <span>Join the Discord (Free)</span>
                 </a>
             </div>
+
+            <section class="video-section" aria-labelledby="video-title">
+                <div class="card video-card">
+                    <h2 id="video-title">Inside Endless Vocals</h2>
+                    <p>Take a look at how we run bootcamps, build vocal habits, and support each other inside the community. Hear
+                        directly from Coach Ryan about how the program unfolds.</p>
+                    <div class="video-frame">
+                        <iframe id="bootcamp-video" src="https://www.youtube-nocookie.com/embed/B0QLk8mLWQE?rel=0"
+                            title="Inside Endless Vocals" loading="lazy"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                    </div>
+                    <a class="video-watch" href="https://www.youtube.com/watch?v=B0QLk8mLWQE" target="_blank" rel="noopener">
+                        Watch it on YouTube
+                    </a>
+                </div>
+            </section>
 
             <div class="grid" style="margin-top:32px">
                 <div class="card" aria-labelledby="whatis">
@@ -657,23 +703,6 @@
                 <img src="images/mics/mic-purple.png" alt="" loading="lazy">
                 <img src="images/mics/mic-turqoise.png" alt="" loading="lazy">
                 <img src="images/mics/pink-mic.png" alt="" loading="lazy">
-            </div>
-        </section>
-
-        <section class="video-section" aria-labelledby="video-title">
-            <div class="card video-card">
-                <h2 id="video-title">Inside Endless Vocals</h2>
-                <p>Take a look at how we run bootcamps, build vocal habits, and support each other inside the community. Hear
-                    directly from Coach Ryan about how the program unfolds.</p>
-                <div class="video-frame">
-                    <iframe id="bootcamp-video" src="https://www.youtube-nocookie.com/embed/B0QLk8mLWQE?rel=0"
-                        title="Inside Endless Vocals" loading="lazy"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-                </div>
-                <a class="video-watch" href="https://www.youtube.com/watch?v=B0QLk8mLWQE" target="_blank" rel="noopener">
-                    Watch it on YouTube
-                </a>
             </div>
         </section>
 
@@ -719,6 +748,12 @@
         <footer class="footer" aria-label="Site footer">
             © <span id="year"></span> Endless Vocals. All rights reserved.
         </footer>
+
+        <div class="back-to-top-wrap">
+            <a class="back-to-top" href="#top" aria-label="Back to the top of the page">
+                ↑ Back to the top
+            </a>
+        </div>
     </div>
 
     <!-- Sticky mobile CTA -->


### PR DESCRIPTION
## Summary
- move the Inside Endless Vocals video into the hero beneath the main headline so it appears near the top of the page
- adjust the video section spacing to fit the hero layout
- add a back-to-the-top button at the bottom of the page to quickly return to the hero

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfe5d23408331834aa9bc75f355ef)