### PR TITLE
Move promo video into hero section and add back-to-top button

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
         }
 
         .video-section {
-            margin: 64px 0 32px;
+            margin: 28px 0 32px;
         }
 
         .video-card {
@@ -430,6 +430,34 @@
             margin: 32px 0
         }
 
+        .back-to-top-wrapper {
+            display: flex;
+            justify-content: center;
+            margin: 24px 0 40px;
+        }
+
+        .back-to-top {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            padding: 14px 18px;
+            border-radius: 999px;
+            background: var(--surface);
+            border: 1px solid var(--surface-border);
+            color: var(--fg);
+            font-weight: 700;
+            box-shadow: 0 10px 24px var(--shadow);
+            transition: transform .2s ease, box-shadow .2s ease, border .2s ease;
+        }
+
+        .back-to-top:focus,
+        .back-to-top:hover {
+            outline: none;
+            transform: translateY(-1px);
+            box-shadow: 0 14px 28px var(--shadow);
+            border-color: rgba(31,92,255,.35);
+        }
+
         .pill {
             display: inline-block;
             padding: 6px 10px;
@@ -589,7 +617,7 @@
         }
     </style>
 </head>
-<body data-theme="light">
+<body id="top" data-theme="light">
     <div class="container">
         <header class="masthead" aria-label="Site header">
             <div class="logo" aria-label="Endless Vocals">ENDLESS <span style="opacity:.7;font-weight:600">vocals</span></div>
@@ -616,6 +644,23 @@
                     <span>Join the Discord (Free)</span>
                 </a>
             </div>
+
+            <section class="video-section" aria-labelledby="video-title">
+                <div class="card video-card">
+                    <h2 id="video-title">Inside Endless Vocals</h2>
+                    <p>Take a look at how we run bootcamps, build vocal habits, and support each other inside the community. Hear
+                        directly from Coach Ryan about how the program unfolds.</p>
+                    <div class="video-frame">
+                        <iframe id="bootcamp-video" src="https://www.youtube-nocookie.com/embed/B0QLk8mLWQE?rel=0"
+                            title="Inside Endless Vocals" loading="lazy"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                    </div>
+                    <a class="video-watch" href="https://www.youtube.com/watch?v=B0QLk8mLWQE" target="_blank" rel="noopener">
+                        Watch it on YouTube
+                    </a>
+                </div>
+            </section>
 
             <div class="grid" style="margin-top:32px">
                 <div class="card" aria-labelledby="whatis">
@@ -660,23 +705,6 @@
             </div>
         </section>
 
-        <section class="video-section" aria-labelledby="video-title">
-            <div class="card video-card">
-                <h2 id="video-title">Inside Endless Vocals</h2>
-                <p>Take a look at how we run bootcamps, build vocal habits, and support each other inside the community. Hear
-                    directly from Coach Ryan about how the program unfolds.</p>
-                <div class="video-frame">
-                    <iframe id="bootcamp-video" src="https://www.youtube-nocookie.com/embed/B0QLk8mLWQE?rel=0"
-                        title="Inside Endless Vocals" loading="lazy"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-                </div>
-                <a class="video-watch" href="https://www.youtube.com/watch?v=B0QLk8mLWQE" target="_blank" rel="noopener">
-                    Watch it on YouTube
-                </a>
-            </div>
-        </section>
-
         <section id="coaches" class="coaches" aria-labelledby="coaches-title">
             <h2 id="coaches-title">Meet the Coaches</h2>
             <p class="lead">The Endless Vocals team blends decades of stage experience, technical mastery, and songwriting craft to help you grow as a vocalist and artist. Get to know the coaches guiding each session and the mentor who set the foundations.</p>
@@ -715,6 +743,10 @@
                 </article>
             </div>
         </section>
+
+        <div class="back-to-top-wrapper">
+            <a class="back-to-top" href="#top" aria-label="Back to top of page">↑ Back to top</a>
+        </div>
 
         <footer class="footer" aria-label="Site footer">
             © <span id="year"></span> Endless Vocals. All rights reserved.


### PR DESCRIPTION
## Summary
- move the Inside Endless Vocals video into the hero beneath the main headline so it appears near the top of the page
- adjust the video section spacing to fit the hero layout
- add a back-to-top button near the footer that scrolls users to the page top

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfe5d23408331834aa9bc75f355ef)