### PR TITLE
Improve mobile navigation and video layout on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,8 +514,25 @@
                 padding: 24px;
             }
 
+            .masthead-right {
+                width: 100%;
+                justify-content: flex-end;
+                gap: 10px;
+                flex-wrap: nowrap;
+            }
+
             nav {
-                display: none;
+                display: flex;
+                gap: 8px;
+                align-items: center;
+            }
+
+            nav a {
+                padding: 10px 12px;
+                font-size: 14px;
+                background: var(--surface);
+                border-color: var(--surface-border);
+                color: var(--fg);
             }
 
             .hero {
@@ -553,7 +570,7 @@
             }
 
             .video-section {
-                padding: 0 24px;
+                padding: 0;
             }
 
             .list {
@@ -561,11 +578,18 @@
             }
 
             .video-card {
+                width: 100%;
+                max-width: none;
                 text-align: center;
+                border-radius: 0;
             }
 
             .video-card p {
                 margin: 0 auto;
+            }
+
+            .video-frame {
+                border-radius: 0;
             }
         }
         /* Sticky mobile footer CTA */


### PR DESCRIPTION
## Summary
- show FAQ and Meet the Coaches links next to the theme toggle on small screens
- let the Inside Endless Vocals video section span the full mobile width

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e084d87708331897de2be8ff6b40a)