### PR TITLE
Refresh homepage for Phase Cycle 2 launch and add Phase Cycle mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,28 @@
             --focus-outline: rgba(255,255,255,.2);
         }
 
+        body[data-theme="phase"] {
+            color-scheme: dark;
+            --bg: #041027;
+            --fg: #e8f5ff;
+            --muted: #afcff5;
+            --surface: rgba(5, 22, 52, 0.86);
+            --surface-strong: #082154;
+            --surface-border: rgba(118, 204, 255, 0.34);
+            --surface-soft: rgba(8, 33, 84, 0.88);
+            --accent: #57d1ff;
+            --accent-2: #8ee7ff;
+            --accent-3: #0b3e97;
+            --accent-alt: #8da8ff;
+            --accent-2-alt: #c4f7ff;
+            --shadow: rgba(0, 17, 44, 0.45);
+            --hero-bg: radial-gradient(1300px 700px at 15% -10%, rgba(87,209,255,.42), transparent 58%), radial-gradient(1000px 600px at 100% 0%, rgba(141,168,255,.34), transparent 60%), linear-gradient(140deg, #031024, #051535 58%, #0a245f 100%);
+            --coaches-bg: linear-gradient(140deg, rgba(87,209,255,.14), rgba(11,62,151,.32));
+            --list-item-bg: rgba(10, 37, 86, 0.76);
+            --note: #c8e6ff;
+            --focus-outline: rgba(118,204,255,.45);
+        }
+
         * {
             box-sizing: border-box
         }
@@ -96,6 +118,25 @@
             padding: 60px 24px;
             background: var(--hero-bg);
             box-shadow: 0 20px 60px var(--shadow);
+        }
+
+        .hero::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity .35s ease;
+        }
+
+        body[data-theme="phase"] .hero::before {
+            opacity: .85;
+            background:
+                repeating-linear-gradient(120deg, rgba(103, 228, 255, .16) 0 2px, transparent 2px 34px),
+                radial-gradient(circle at 15% 20%, rgba(135, 247, 255, .42), transparent 32%),
+                radial-gradient(circle at 85% 12%, rgba(141, 168, 255, .34), transparent 28%);
+            mix-blend-mode: screen;
+            animation: phasePulse 8s linear infinite;
         }
 
         .masthead {
@@ -233,6 +274,37 @@
             grid-template-columns: 1.1fr .9fr;
             gap: 28px;
             align-items: center
+        }
+
+        .phase-grid {
+            display: grid;
+            grid-template-columns: 1.1fr .9fr;
+            gap: 22px;
+            margin-top: 28px;
+            align-items: stretch;
+        }
+
+        .phase-photo {
+            width: 100%;
+            border-radius: 16px;
+            object-fit: cover;
+            box-shadow: 0 14px 28px var(--shadow);
+            border: 1px solid var(--surface-border);
+        }
+
+        .phase-photo.main {
+            aspect-ratio: 4/3;
+        }
+
+        .phase-photo-row {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 12px;
+            margin-top: 12px;
+        }
+
+        .phase-photo-row .phase-photo {
+            aspect-ratio: 1 / 1;
         }
 
         .card {
@@ -478,6 +550,64 @@
                     color: var(--accent);
                 }
 
+        .schedule {
+            margin-top: 32px;
+        }
+
+        .schedule-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 12px;
+            margin-top: 14px;
+        }
+
+        .schedule-item {
+            background: var(--list-item-bg);
+            border: 1px solid var(--surface-border);
+            border-radius: 14px;
+            padding: 14px;
+        }
+
+        .schedule-item strong {
+            display: block;
+            margin-bottom: 8px;
+            color: var(--accent);
+        }
+
+        .schedule-item span {
+            display: block;
+            color: var(--muted);
+            font-size: 14px;
+        }
+
+        .phase-particles {
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            overflow: hidden;
+        }
+
+        .phase-particles span {
+            position: absolute;
+            width: 2px;
+            height: 120px;
+            background: linear-gradient(to bottom, rgba(186,246,255,0), rgba(186,246,255,.95), rgba(186,246,255,0));
+            filter: drop-shadow(0 0 6px rgba(87, 209, 255, .8));
+            opacity: 0;
+            animation: lightning 5.6s linear infinite;
+        }
+
+        body[data-theme="phase"] .phase-particles span {
+            opacity: .75;
+        }
+
+        .phase-particles span:nth-child(1) { left: 8%; top: 20%; animation-delay: .2s; transform: rotate(15deg); }
+        .phase-particles span:nth-child(2) { left: 22%; top: 42%; animation-delay: 1.1s; transform: rotate(-14deg); }
+        .phase-particles span:nth-child(3) { left: 43%; top: 15%; animation-delay: 2s; transform: rotate(11deg); }
+        .phase-particles span:nth-child(4) { left: 58%; top: 40%; animation-delay: 2.8s; transform: rotate(-12deg); }
+        .phase-particles span:nth-child(5) { left: 74%; top: 22%; animation-delay: 3.7s; transform: rotate(9deg); }
+        .phase-particles span:nth-child(6) { left: 88%; top: 46%; animation-delay: 4.6s; transform: rotate(-8deg); }
+
         .note {
             font-size: 13px;
             color: var(--note)
@@ -596,6 +726,11 @@
             .video-frame {
                 border-radius: 0;
             }
+
+            .phase-grid,
+            .schedule-grid {
+                grid-template-columns: 1fr;
+            }
         }
         /* Sticky mobile footer CTA */
         .sticky {
@@ -625,6 +760,23 @@
         body[data-theme="dark"] .sticky {
             background: linear-gradient(180deg, rgba(10,10,12,.0), rgba(10,10,12,.8) 30%, rgba(10,10,12,.95));
         }
+
+        body[data-theme="phase"] .sticky {
+            background: linear-gradient(180deg, rgba(4,16,39,.0), rgba(4,16,39,.78) 30%, rgba(4,16,39,.95));
+        }
+
+        @keyframes lightning {
+            0%, 26%, 100% { opacity: 0; transform: translateY(0) scaleY(.9); }
+            28% { opacity: .92; }
+            31% { opacity: .28; }
+            34% { opacity: .84; transform: translateY(5px) scaleY(1.08); }
+            40% { opacity: 0; transform: translateY(15px) scaleY(1); }
+        }
+
+        @keyframes phasePulse {
+            0%, 100% { transform: scale(1); }
+            50% { transform: scale(1.04); }
+        }
     </style>
 </head>
 <body id="top" data-theme="light">
@@ -637,7 +789,7 @@
                     <a href="#coaches">Coaches</a>
                     <a href="shop.html">Shop</a>
                 </nav>
-                <button id="theme-toggle" class="mode-toggle" type="button" aria-label="Switch to dark mode">
+                <button id="theme-toggle" class="mode-toggle" type="button" aria-label="Switch display mode">
                     <span id="theme-toggle-icon" aria-hidden="true">🌞</span>
                     <span id="theme-toggle-text">Light Mode</span>
                 </button>
@@ -645,15 +797,38 @@
         </header>
 
         <section class="hero" aria-labelledby="h1">
-            <h1 id="h1" class="title">Your Vocals Don’t Expire</h1>
-            <p class="subtitle">Practical training, clear structure, steady progress. Two‑month bootcamps with Ryan Wall and Tiago Costa. Live sessions, replays, and a friendly Discord to keep you moving.</p>
+            <div class="phase-particles" aria-hidden="true">
+                <span></span><span></span><span></span><span></span><span></span><span></span>
+            </div>
+            <h1 id="h1" class="title">Phase Cycle 2 Is Live</h1>
+            <p class="subtitle">Stepping through the Phase Cycle is like walking through a blue energy field that resets and reshapes your voice. Once you pass through it, there is no going back—you begin a new training arc with an intensified two‑month bootcamp.</p>
             <div class="cta-row" role="group" aria-label="Primary actions">
                 <a class="btn btn-primary" href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener noreferrer" aria-label="Sign up at Ko‑fi">
-                    <span>Sign Up at Ko‑fi — $24/mo</span>
+                    <span>Join Phase Cycle 2 — $24/mo</span>
                 </a>
                 <a class="btn btn-secondary" href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener noreferrer" aria-label="Join the Discord">
                     <span>Join the Discord (Free)</span>
                 </a>
+            </div>
+
+            <div class="phase-grid" aria-label="Phase Cycle visuals">
+                <div class="card">
+                    <img class="phase-photo main" src="images/EV_PC2_optimized.jpg" alt="Phase Cycle 2 visual showing blue energy styling." loading="lazy">
+                    <div class="phase-photo-row">
+                        <img class="phase-photo" src="images/phase cycle square_optimized.jpg" alt="Phase Cycle square teaser art." loading="lazy">
+                        <img class="phase-photo" src="images/phase cycle draft better.png" alt="Phase Cycle concept art." loading="lazy">
+                        <img class="phase-photo" src="images/phase_mobile_cycle_optimized.jpg" alt="Phase Cycle mobile key art." loading="lazy">
+                    </div>
+                </div>
+                <div class="card">
+                    <h3>Phase Cycle 2 timeline</h3>
+                    <p>Bootcamp starts <strong>Monday, April 6, 2026</strong> and runs through <strong>Sunday, May 31, 2026</strong>. Weekly clinics happen every Monday at 6:00 PM.</p>
+                    <div class="list" aria-label="Phase Cycle 2 highlights">
+                        <div class="item">Reset + Rebuild your baseline in Week 1</div>
+                        <div class="item">ISO Method, warmups, and vocal tech progression</div>
+                        <div class="item">Song performance, DAW tools, and artist growth</div>
+                    </div>
+                </div>
             </div>
 
             <section class="video-section" aria-labelledby="video-title">
@@ -675,27 +850,42 @@
 
             <div class="grid" style="margin-top:32px">
                 <div class="card" aria-labelledby="whatis">
-                    <h3 id="whatis">What is Endless Vocals?</h3>
-                    <p>It’s a modern training space for singers who want to get straight to the point about improving their singing skill. We keep what works, focus on repeatable habits, and measure progress by what you can feel and perform—on stage and in the studio.</p>
+                    <h3 id="whatis">What is the Phase Cycle?</h3>
+                    <p>The Phase Cycle is where singers reset, intensify, and level up. It’s structured for consistency and momentum: every week you build on the previous clinic so your voice, confidence, and musical skill move forward together.</p>
                     <div class="list" aria-label="Highlights">
-                        <div class="item">Two‑Month Bootcamps with Ryan or Tiago</div>
-                        <div class="item">Live sessions + replays you can follow</div>
-                        <div class="item">Free Discord for clips, feedback, and community</div>
+                        <div class="item">8 live weekly clinics (Mondays at 6:00 PM)</div>
+                        <div class="item">Replays + practical drills to lock in progress</div>
+                        <div class="item">Community support in Discord between clinics</div>
                     </div>
-                    <p class="note" style="margin-top:10px">The bootcamp has begun, but you can still join mid-bootcamp. Join ASAP to get the most out of Ryan's bootcamp taking place from Dec 1st to January 31st. After Ryan's bootcamp, it will be Coach Tiago's class for 2 months, and the cycle repeats. Stay in the school for consistent vocal training!</p>
-                    <p class="note" style="margin-top:8px">You’ll also learn how to create your own songs from scratch, learn to use a DAW for recording because it's a critical part of becoming a singer, and tackle lyric writing.</p>
+                    <p class="note" style="margin-top:10px">Once you step through the Phase Cycle, you begin a higher training arc. It’s a full reset that reshapes how you train, sing, and perform.</p>
+                    <p class="note" style="margin-top:8px">You’ll also learn song execution, genre expansion, DAW workflow, and practical artist tools for studio-ready growth.</p>
                 </div>
                 <div class="card" aria-labelledby="about">
-                    <h3 id="about">Why a new school?</h3>
-                    <p><strong>Vendera Vocal Academy has sadly come to a close.</strong> Jaime graciously encouraged us to continue helping singers in a new format. Endless Vocals is our way forward—built with care by Ryan Wall and Tiago Costa.</p>
-                    <p class="note">“Jaime has given us his full blessing to continue teaching his ISO Method to help singers raise their voice in a different format.”</p>
+                    <h3 id="about">Phase Cycle 2 weekly clinics</h3>
+                    <p><strong>Week 1 — Enter the Phase Cycle — Reset</strong><br>Monday, April 6, 2026 at 6:00 PM</p>
+                    <p><strong>Week 2 — Powering Up the Voice (Warm Ups + Vocal Health + Fitness)</strong><br>Monday, April 13, 2026 at 6:00 PM</p>
+                    <p class="note">Week 3 — The ISO Method and the ISO Exercises · Monday, April 20, 2026 at 6:00 PM</p>
                     <div style="margin-top:8px">
-                        <span class="pill">Live • Practical • Friendly</span>
-                        <span class="pill">Start/Stop Anytime</span>
-                        <span class="pill">Beginner → Pro</span>
+                        <span class="pill">Week 4: Singing Songs</span>
+                        <span class="pill">Week 5: Recap + Test Day</span>
+                        <span class="pill">Week 6-8: Vocal Tech + Tools</span>
                     </div>
                 </div>
             </div>
+
+            <section class="card schedule" aria-labelledby="schedule-title">
+                <h3 id="schedule-title">Full clinic schedule (April 6 to May 31, 2026)</h3>
+                <div class="schedule-grid">
+                    <div class="schedule-item"><strong>Week 1 — Enter the Phase Cycle — Reset</strong><span>Monday, April 6, 2026 · 6:00 PM</span></div>
+                    <div class="schedule-item"><strong>Week 2 — Powering Up the Voice</strong><span>Monday, April 13, 2026 · 6:00 PM</span></div>
+                    <div class="schedule-item"><strong>Week 3 — The ISO Method + ISO Exercises</strong><span>Monday, April 20, 2026 · 6:00 PM</span></div>
+                    <div class="schedule-item"><strong>Week 4 — Singing Songs (Playlist + Genre Expansion)</strong><span>Monday, April 27, 2026 · 6:00 PM</span></div>
+                    <div class="schedule-item"><strong>Week 5 — Recap &amp; Reinforcement — Test Day</strong><span>Monday, May 4, 2026 · 6:00 PM</span></div>
+                    <div class="schedule-item"><strong>Week 6 — Vocal Tech — Runs &amp; Vibrato</strong><span>Monday, May 11, 2026 · 6:00 PM</span></div>
+                    <div class="schedule-item"><strong>Week 7 — Vocal Tech — Grit &amp; Screams</strong><span>Monday, May 18, 2026 · 6:00 PM</span></div>
+                    <div class="schedule-item"><strong>Week 8 — Tech Talk (DAWs, Plugins, Apps)</strong><span>Monday, May 25, 2026 · 6:00 PM</span></div>
+                </div>
+            </section>
 
             <div class="divider"></div>
 
@@ -790,12 +980,15 @@
         savedTheme = null;
     }
 
-    const initialTheme = savedTheme || 'light';
+    const validThemes = ['light', 'dark', 'phase'];
+    const initialTheme = validThemes.includes(savedTheme) ? savedTheme : 'light';
     applyTheme(initialTheme);
 
     if (themeToggle) {
         themeToggle.addEventListener('click', () => {
-            const nextTheme = body.dataset.theme === 'dark' ? 'light' : 'dark';
+            const current = body.dataset.theme || 'light';
+            const currentIndex = validThemes.indexOf(current);
+            const nextTheme = validThemes[(currentIndex + 1) % validThemes.length];
             applyTheme(nextTheme);
         });
     }
@@ -815,6 +1008,10 @@
         if (theme === 'dark') {
             iconEl.textContent = '🌙';
             textEl.textContent = 'Dark Mode';
+            themeToggle.setAttribute('aria-label', 'Switch to phase cycle mode');
+        } else if (theme === 'phase') {
+            iconEl.textContent = '⚡';
+            textEl.textContent = 'Phase Cycle Mode';
             themeToggle.setAttribute('aria-label', 'Switch to light mode');
         } else {
             iconEl.textContent = '🌞';


### PR DESCRIPTION
### Motivation
- Spotlight the new Phase Cycle 2 bootcamp running from Monday, April 6, 2026 through the end of May 2026 to drive signups and attendance. 
- Give the top of the site a fresh, attention-grabbing visual treatment that matches the Phase Cycle concept with a blue energy palette and motion. 
- Preserve existing sections (coaches, FAQ, shop) while updating hero, imagery, and schedule content. 

### Description
- Updated `index.html` hero copy and CTAs to announce "Phase Cycle 2 Is Live" and changed the primary CTA to `Join Phase Cycle 2 — $24/mo`. 
- Added Phase Cycle imagery into the hero using assets from `images/` (`EV_PC2_optimized.jpg`, `phase cycle square_optimized.jpg`, `phase cycle draft better.png`, `phase_mobile_cycle_optimized.jpg`). 
- Introduced a new theme mode via `body[data-theme="phase"]` with blue palette variables, a hero overlay, and animated lightning particle effects implemented with CSS and a small DOM element (`.phase-particles`). 
- Added a full 8-week clinic schedule section and responsive layout (`.phase-grid`, `.schedule-grid`) and updated the theme toggle JS to cycle `['light','dark','phase']` and show a phase icon. 

### Testing
- Ran an HTML parse using a small Python snippet with `html.parser` that loaded `index.html`, which completed successfully. 
- Attempted `xmllint --html --noout index.html`, but `xmllint` is not available in the environment so that check could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40e6adedc8331b0565ee89302df0d)