### PR TITLE
Add Song Mapper navigation link and landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -813,6 +813,7 @@
                     <a href="faq.html">FAQ</a>
                     <a href="#coaches">Coaches</a>
                     <a href="shop.html">Shop</a>
+                    <a href="/song-mapper">Song Mapper</a>
                 </nav>
                 <button id="theme-toggle" class="mode-toggle" type="button" aria-label="Switch to dark mode">
                     <span id="theme-toggle-icon" aria-hidden="true">🌞</span>

--- a/song-mapper/index.html
+++ b/song-mapper/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Song Mapper — Endless Vocals</title>
+  <meta name="description" content="Song Mapper by Endless Vocals helps singers map song sections, training goals, and progress." />
+  <style>
+    :root {
+      --bg: #f6f9ff;
+      --fg: #0c182b;
+      --muted: #50627a;
+      --card: #ffffff;
+      --accent: #1f5cff;
+      --border: rgba(37, 74, 140, 0.18);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+    }
+
+    .card {
+      width: min(760px, 100%);
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 28px;
+      box-shadow: 0 18px 45px rgba(15, 51, 120, 0.12);
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(28px, 4vw, 44px);
+      line-height: 1.1;
+    }
+
+    p {
+      margin: 0 0 12px;
+      font-size: 18px;
+      color: var(--muted);
+    }
+
+    .actions {
+      margin-top: 20px;
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      border-radius: 999px;
+      padding: 11px 16px;
+      font-size: 15px;
+      font-weight: 700;
+      text-decoration: none;
+      border: 1px solid transparent;
+      transition: transform .15s ease, box-shadow .15s ease;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+      box-shadow: 0 10px 22px rgba(31, 92, 255, .25);
+    }
+
+    .btn-secondary {
+      background: transparent;
+      color: var(--fg);
+      border-color: var(--border);
+    }
+
+    .btn:hover {
+      transform: translateY(-1px);
+    }
+  </style>
+</head>
+<body>
+  <main class="card" aria-labelledby="song-mapper-title">
+    <h1 id="song-mapper-title">Song Mapper</h1>
+    <p>Welcome to the Song Mapper page for Endless Vocals.</p>
+    <p>This route is now live at <strong>https://endlessvocals.com/song-mapper</strong>.</p>
+    <div class="actions">
+      <a class="btn btn-primary" href="/">Back to Home</a>
+      <a class="btn btn-secondary" href="/faq.html">View FAQ</a>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a header navigation button that links to a new Song Mapper landing page so visitors can open the Song Mapper app at `/song-mapper`.

### Description
- Inserted `<a href="/song-mapper">Song Mapper</a>` into the masthead navigation in `index.html` and added a new `song-mapper/index.html` file that provides a minimal landing page with title, description, simple styling, and action links back to home and FAQ.

### Testing
- Ran `git status --short` and `git log -1 --oneline` to verify the changed files and the latest commit, and both checks returned the expected output indicating the new files are present and the change was recorded successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8d91b1e0833182879729eb0e9ea3)