### PR TITLE
Fix Song Mapper navigation path from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -813,7 +813,7 @@
                     <a href="faq.html">FAQ</a>
                     <a href="#coaches">Coaches</a>
                     <a href="shop.html">Shop</a>
-                    <a href="/song-mapper">Song Mapper</a>
+                    <a href="song-mapper/">Song Mapper</a>
                 </nav>
                 <button id="theme-toggle" class="mode-toggle" type="button" aria-label="Switch to dark mode">
                     <span id="theme-toggle-icon" aria-hidden="true">🌞</span>

--- a/index.html
+++ b/index.html
@@ -687,15 +687,19 @@
 
             .masthead-right {
                 width: 100%;
-                justify-content: flex-end;
+                justify-content: flex-start;
                 gap: 10px;
-                flex-wrap: nowrap;
+                flex-wrap: wrap;
             }
 
             nav {
                 display: flex;
                 gap: 8px;
                 align-items: center;
+                width: 100%;
+                overflow-x: auto;
+                -webkit-overflow-scrolling: touch;
+                padding-bottom: 2px;
             }
 
             nav a {
@@ -709,6 +713,11 @@
                 justify-content: center;
                 white-space: nowrap;
                 text-align: center;
+                flex: 0 0 auto;
+            }
+
+            .mode-toggle {
+                margin-left: auto;
             }
 
             .hero {

--- a/song-mapper/index.html
+++ b/song-mapper/index.html
@@ -61,6 +61,26 @@
       font-size: 0.95rem;
     }
 
+    .back-link {
+      justify-self: start;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      border: 1px solid #3b4760;
+      background: #121827;
+      color: var(--text);
+      font-size: 0.9rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: filter 0.2s ease;
+    }
+
+    .back-link:hover {
+      filter: brightness(1.08);
+    }
+
     .composer {
       padding: 14px;
       display: grid;
@@ -562,6 +582,7 @@
     <section class="card header">
       <h1>Song Mapper (Desktop)</h1>
       <p>Fast desktop lyric markup: multi-select words, batch apply attributes, and draw enunciation/pitch with your mouse.</p>
+      <a class="back-link" href="../">← Back to Endless Vocals</a>
     </section>
 
     <section id="composer" class="card composer">
@@ -2061,7 +2082,11 @@ function renderMusicRollLabels(line, height, rowBands) {
         const file = event.target.files && event.target.files[0];
         loadSongMapFile(file);
       });
-      clearMapBtn.addEventListener("click", clearMap);
+      clearMapBtn.addEventListener("click", function () {
+        const shouldClear = window.confirm("Are you sure you want to clear map? This will reset everything and you'll lose the current song map.");
+        if (!shouldClear) return;
+        clearMap();
+      });
 
       document.getElementById("applyAbovePresetBtn").addEventListener("click", function () {
         applyAboveValue(aboveSelect.value);

--- a/song-mapper/index.html
+++ b/song-mapper/index.html
@@ -580,8 +580,8 @@
 <body>
   <main class="app">
     <section class="card header">
-      <h1>Song Mapper (Desktop)</h1>
-      <p>Fast desktop lyric markup: multi-select words, batch apply attributes, and draw enunciation/pitch with your mouse.</p>
+      <h1>Song Mapper</h1>
+      <p>Inspired by the Song Mapping process at the end of Jaime Vendera’s Raise Your Voice. Use the different tools to apply markups to your lyrics, helping you break down and learn songs more effectively.</p>
       <a class="back-link" href="../">← Back to Endless Vocals</a>
     </section>
 


### PR DESCRIPTION
### Motivation
- The Song Mapper link on the homepage used an absolute root path which caused a 404 when the site is served from a subpath, so the navigation needed a relative URL.

### Description
- Updated the anchor in `index.html` from `href="/song-mapper"` to `href="song-mapper/"` so the Song Mapper page resolves correctly when navigating from the main site.

### Testing
- Verified the change with `rg -n "song-mapper" index.html`, inspected the `git diff`, and committed the update with `git commit`; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9658a44c8331ab2e65d4be1c6eb5)