### PR TITLE
Improve mobile layout and Song Mapper UX (responsive styles, back link, clear confirmation)

### DIFF
--- a/index.html
+++ b/index.html
@@ -687,15 +687,19 @@
 
             .masthead-right {
                 width: 100%;
-                justify-content: flex-end;
+                justify-content: flex-start;
                 gap: 10px;
-                flex-wrap: nowrap;
+                flex-wrap: wrap;
             }
 
             nav {
                 display: flex;
                 gap: 8px;
                 align-items: center;
+                width: 100%;
+                overflow-x: auto;
+                -webkit-overflow-scrolling: touch;
+                padding-bottom: 2px;
             }
 
             nav a {
@@ -709,6 +713,11 @@
                 justify-content: center;
                 white-space: nowrap;
                 text-align: center;
+                flex: 0 0 auto;
+            }
+
+            .mode-toggle {
+                margin-left: auto;
             }
 
             .hero {
@@ -813,7 +822,7 @@
                     <a href="faq.html">FAQ</a>
                     <a href="#coaches">Coaches</a>
                     <a href="shop.html">Shop</a>
-                    <a href="/song-mapper">Song Mapper</a>
+                    <a href="song-mapper/">Song Mapper</a>
                 </nav>
                 <button id="theme-toggle" class="mode-toggle" type="button" aria-label="Switch to dark mode">
                     <span id="theme-toggle-icon" aria-hidden="true">🌞</span>

--- a/song-mapper/index.html
+++ b/song-mapper/index.html
@@ -61,6 +61,26 @@
       font-size: 0.95rem;
     }
 
+    .back-link {
+      justify-self: start;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      border: 1px solid #3b4760;
+      background: #121827;
+      color: var(--text);
+      font-size: 0.9rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: filter 0.2s ease;
+    }
+
+    .back-link:hover {
+      filter: brightness(1.08);
+    }
+
     .composer {
       padding: 14px;
       display: grid;
@@ -555,13 +575,144 @@
       color: #d5def0;
       font: 500 13px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
     }
+
+    @media (max-width: 980px) {
+      .app {
+        padding: 12px;
+      }
+
+      .workspace {
+        grid-template-columns: 1fr;
+      }
+
+      .map-wrap {
+        min-height: 420px;
+      }
+
+      #map {
+        min-height: 360px;
+      }
+
+      .side-panel {
+        position: static;
+        top: auto;
+        max-height: none;
+        overflow: visible;
+      }
+
+      .topbar {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .song-label {
+        justify-self: stretch;
+        grid-column: 1 / -1;
+        min-width: 0;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .app {
+        padding: 10px;
+        gap: 10px;
+      }
+
+      .header h1 {
+        font-size: 1.45rem;
+      }
+
+      .header p {
+        font-size: 0.92rem;
+        line-height: 1.45;
+      }
+
+      .back-link {
+        width: 100%;
+        justify-content: center;
+        padding: 10px 14px;
+      }
+
+      .composer,
+      .map-wrap,
+      .side-panel {
+        padding: 11px;
+      }
+
+      .generate-row {
+        display: grid;
+        grid-template-columns: 1fr;
+      }
+
+      .generate-row button,
+      .topbar button,
+      .group > button,
+      .row button {
+        min-height: 42px;
+      }
+
+      .mode-row {
+        grid-template-columns: 1fr 1fr;
+      }
+
+      .row {
+        grid-template-columns: 1fr;
+      }
+
+      .line-row {
+        grid-template-columns: 30px minmax(0, 1fr);
+        gap: 6px;
+      }
+
+      .line-handle {
+        width: 28px;
+        height: 28px;
+      }
+
+      .line-words {
+        gap: 5px;
+      }
+
+      .word-card {
+        min-width: 64px;
+        max-width: 150px;
+        padding: 5px 7px 7px;
+        grid-template-rows: 20px auto 18px;
+      }
+
+      .annotation {
+        font-size: 10px;
+      }
+
+      .word {
+        font-size: 16px;
+      }
+
+      .topbar {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 420px) {
+      .mode-row {
+        grid-template-columns: 1fr;
+      }
+
+      .word-card {
+        min-width: 58px;
+      }
+
+      #exportBox {
+        font-size: 12px;
+      }
+    }
   </style>
 </head>
 <body>
   <main class="app">
     <section class="card header">
-      <h1>Song Mapper (Desktop)</h1>
-      <p>Fast desktop lyric markup: multi-select words, batch apply attributes, and draw enunciation/pitch with your mouse.</p>
+      <h1>Song Mapper</h1>
+      <p>Inspired by the Song Mapping process at the end of Jaime Vendera’s Raise Your Voice. Use the different tools to apply markups to your lyrics, helping you break down and learn songs more effectively.</p>
+      <a class="back-link" href="../">← Back to Endless Vocals</a>
     </section>
 
     <section id="composer" class="card composer">
@@ -2061,7 +2212,11 @@ function renderMusicRollLabels(line, height, rowBands) {
         const file = event.target.files && event.target.files[0];
         loadSongMapFile(file);
       });
-      clearMapBtn.addEventListener("click", clearMap);
+      clearMapBtn.addEventListener("click", function () {
+        const shouldClear = window.confirm("Are you sure you want to clear map? This will reset everything and you'll lose the current song map.");
+        if (!shouldClear) return;
+        clearMap();
+      });
 
       document.getElementById("applyAbovePresetBtn").addEventListener("click", function () {
         applyAboveValue(aboveSelect.value);


### PR DESCRIPTION
### Motivation
- Improve mobile navigation and masthead layout so the header and nav behave correctly on small viewports.
- Make the Song Mapper page more usable on phones by adding responsive styles and a clear path back to the main site.
- Prevent accidental data loss by prompting for confirmation before clearing a song map.

### Description
- Adjusted header/masthead styles: `.masthead-right` now uses `justify-content: flex-start` and `flex-wrap: wrap`, `nav` gains `overflow-x: auto` and touch scrolling, `nav a` is `flex: 0 0 auto`, and `.mode-toggle` gets `margin-left: auto` to improve mobile layout.
- Normalized the Song Mapper link in the header to a relative folder path `song-mapper/` to ensure correct linking.
- Updated `song-mapper/index.html` UI: added a `back-link` element and styles, revised the header title/description, and introduced multiple responsive media queries (`@media (max-width: 980px)`, `600px`, and `420px`) to adapt the app, workspace, map, side-panel, toolbar, and card layouts for smaller screens.
- Added a confirmation prompt to the clear action by replacing the `clearMapBtn` handler with a wrapper that calls `window.confirm(...)` and invokes `clearMap()` only on user confirmation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9658a44c8331ab2e65d4be1c6eb5)