### PR TITLE
Add Scream Center landing page and rotate homepage social thumbnail

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,12 @@
     <meta property="og:url" content="https://endlessvocals.com/" />
     <meta property="og:title" content="Endless Vocals — Your Vocals Don’t Expire" />
     <meta property="og:description" content="Phase Cycle 2 is live from April 6, 2026 through May 31, 2026. Join Endless Vocals for an intensified two-month bootcamp with weekly clinics, replays, and community support." />
-    <meta property="og:image" content="https://endlessvocals.com/images/endless_thumbnail.png" />
+    <meta property="og:image" content="https://endlessvocals.com/images/endless_thumbnail.png" id="meta-og-image" />
     <meta property="og:image:alt" content="Endless Vocals brand illustration" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Endless Vocals — Your Vocals Don’t Expire" />
     <meta name="twitter:description" content="Phase Cycle 2 is live from April 6, 2026 through May 31, 2026. Join Endless Vocals for an intensified two-month bootcamp with weekly clinics, replays, and community support." />
-    <meta name="twitter:image" content="https://endlessvocals.com/images/endless_thumbnail.png" />
+    <meta name="twitter:image" content="https://endlessvocals.com/images/endless_thumbnail.png" id="meta-twitter-image" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
@@ -811,6 +811,38 @@
             background: linear-gradient(180deg, rgba(3,14,30,.0), rgba(3,14,30,.82) 30%, rgba(3,14,30,.95));
         }
     </style>
+
+    <script>
+    (function rotateSocialThumbnail() {
+        const variants = [
+            'https://endlessvocals.com/images/endless_thumbnail.png',
+            'https://endlessvocals.com/images/phase cycle draft better.png',
+            'https://endlessvocals.com/images/phase cycle square_optimized.jpg',
+            'https://endlessvocals.com/images/EV_PC2_optimized.jpg'
+        ];
+        const key = 'ev-social-thumb-idx';
+        let idx = 0;
+        try {
+            idx = Number(localStorage.getItem(key) || '0');
+            if (!Number.isFinite(idx) || idx < 0) idx = 0;
+        } catch (err) {
+            idx = Math.floor(Math.random() * variants.length);
+        }
+
+        const selected = variants[idx % variants.length];
+        const ogImage = document.getElementById('meta-og-image');
+        const twitterImage = document.getElementById('meta-twitter-image');
+        if (ogImage) ogImage.setAttribute('content', selected);
+        if (twitterImage) twitterImage.setAttribute('content', selected);
+
+        try {
+            localStorage.setItem(key, String((idx + 1) % variants.length));
+        } catch (err) {
+            // localStorage might be unavailable
+        }
+    })();
+    </script>
+
 </head>
 <body id="top" data-theme="light">
     <canvas id="phase-background" aria-hidden="true"></canvas>
@@ -820,6 +852,7 @@
             <div class="masthead-right">
                 <nav aria-label="Site navigation">
                     <a href="faq.html">FAQ</a>
+                    <a href="scream-center.html">Scream Center</a>
                     <a href="#coaches">Coaches</a>
                     <a href="shop.html">Shop</a>
                     <a href="song-mapper/">Song Mapper</a>
@@ -838,6 +871,9 @@
             <div class="cta-row" role="group" aria-label="Primary actions">
                 <a class="btn btn-primary" href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener noreferrer" aria-label="Sign up at Ko‑fi">
                     <span>Join Phase Cycle 2 — $24/mo</span>
+                </a>
+                <a class="btn btn-secondary" href="scream-center.html" aria-label="Explore Scream Center">
+                    <span>Explore Scream Center</span>
                 </a>
                 <a class="btn btn-secondary" href="https://discord.gg/eQMNpUA687" target="_blank" rel="noopener noreferrer" aria-label="Join the Discord">
                     <span>Join the Discord (Free)</span>

--- a/scream-center.html
+++ b/scream-center.html
@@ -1,0 +1,911 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Scream Center — Endless Vocals</title>
+    <meta name="description" content="Scream Center is an upcoming Endless Vocals course for vocal fry, fry screams, frustrated sigh, low grit, grit slides, safety, resets, and aggressive singing." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://endlessvocals.com/scream-center.html" />
+    <meta property="og:title" content="Scream Center — Endless Vocals" />
+    <meta property="og:description" content="A new vocal screaming course focused on grit, screams, harsh vocals, and aggressive singing." />
+    <meta property="og:image" content="https://endlessvocals.com/images/Scream Center 821.png" />
+    <meta property="og:image:alt" content="Scream Center artwork with singer holding a chain" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Scream Center — Endless Vocals" />
+    <meta name="twitter:description" content="Train the ingredients behind screams safely and confidently with Endless Vocals." />
+    <meta name="twitter:image" content="https://endlessvocals.com/images/Scream Center 821.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700;800;900&family=Inter:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            color-scheme: dark;
+            --ink: #f4efe7;
+            --muted: #d5c7ad;
+            --red: #6f0902;
+            --ember: #a65f08;
+            --gold: #c49a35;
+            --gold-bright: #f4df9f;
+            --silver: #d8d3c6;
+            --smoke: #5a5658;
+            --space-blue: #151b6f;
+            --purple: #40205d;
+            --violet: #8f61be;
+            --glass: rgba(10, 8, 8, .74);
+            --glass-strong: rgba(13, 10, 11, .9);
+            --border: rgba(226, 204, 144, .22);
+            --shadow: rgba(0, 0, 0, .58);
+        }
+
+        * { box-sizing: border-box; }
+
+        html {
+            scroll-behavior: smooth;
+            background: #09030a;
+        }
+
+        body {
+            min-height: 100vh;
+            margin: 0;
+            font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            color: var(--ink);
+            background:
+                radial-gradient(circle at 50% 10%, rgba(174, 124, 24, .64), transparent 26%),
+                radial-gradient(circle at 46% 28%, rgba(220, 184, 104, .28), transparent 19%),
+                radial-gradient(circle at 14% 16%, rgba(103, 8, 2, .36), transparent 26%),
+                radial-gradient(circle at 78% 28%, rgba(54, 47, 48, .45), transparent 24%),
+                linear-gradient(180deg, #020201 0%, #070503 16%, #241305 33%, #111011 47%, #1a1930 59%, #0a103d 73%, #241038 88%, #03020a 100%);
+            overflow-x: hidden;
+        }
+
+        body::before,
+        body::after {
+            content: "";
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        body::before {
+            background:
+                radial-gradient(circle at 50% 7%, rgba(213, 165, 59, .58), transparent 24%),
+                radial-gradient(circle at 44% 31%, rgba(244, 223, 159, .28), transparent 20%),
+                radial-gradient(circle at 12% 8%, rgba(0, 0, 0, .78), transparent 28%),
+                radial-gradient(circle at 96% 10%, rgba(0, 0, 0, .86), transparent 31%),
+                radial-gradient(circle at 22% 69%, rgba(21, 27, 111, .3), transparent 28%),
+                radial-gradient(circle at 84% 73%, rgba(143, 97, 190, .25), transparent 31%);
+            mix-blend-mode: screen;
+            opacity: .88;
+        }
+
+        body::after {
+            background-image:
+                radial-gradient(circle, rgba(244, 223, 159, .72) 0 1px, transparent 1.7px),
+                radial-gradient(circle, rgba(170, 188, 255, .78) 0 1px, transparent 1.5px),
+                radial-gradient(circle, rgba(166, 95, 8, .68) 0 1.2px, transparent 2px);
+            background-size: 120px 120px, 180px 180px, 90px 90px;
+            background-position: 0 0, 24px 74px, 48px 26px;
+            animation: starDrift 38s linear infinite;
+            opacity: .34;
+        }
+
+        a { color: inherit; text-decoration: none; }
+
+        .particle-canvas {
+            position: fixed;
+            inset: 0;
+            z-index: 1;
+            pointer-events: none;
+            width: 100%;
+            height: 100%;
+        }
+
+        .page {
+            position: relative;
+            z-index: 2;
+            max-width: 1180px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .masthead {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 18px;
+            padding: 12px 0 34px;
+        }
+
+        .logo {
+            font-family: Cinzel, Georgia, serif;
+            font-weight: 800;
+            letter-spacing: 3px;
+            font-size: clamp(20px, 3vw, 28px);
+            text-transform: uppercase;
+            color: var(--silver);
+            text-shadow: 0 2px 0 #070707, 0 0 18px rgba(244, 223, 159, .2);
+        }
+
+        .nav {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+        }
+
+        .nav a,
+        .top-link,
+        .scale-controls button {
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: rgba(0, 0, 0, .32);
+            color: var(--silver);
+            font-family: Cinzel, Georgia, serif;
+            font-size: 14px;
+            font-weight: 700;
+            padding: 10px 15px;
+            cursor: pointer;
+            transition: transform .2s ease, background .2s ease, border-color .2s ease;
+        }
+
+        .nav a:hover,
+        .nav a:focus,
+        .top-link:hover,
+        .top-link:focus,
+        .scale-controls button:hover,
+        .scale-controls button:focus {
+            outline: none;
+            transform: translateY(-1px);
+            background: rgba(196, 154, 53, .14);
+            border-color: rgba(244, 223, 159, .42);
+        }
+
+        .hero {
+            position: relative;
+            min-height: 78vh;
+            display: grid;
+            align-items: center;
+            overflow: hidden;
+            border: 1px solid rgba(196, 154, 53, .34);
+            border-radius: 34px;
+            padding: clamp(34px, 7vw, 78px);
+            background:
+                radial-gradient(circle at 50% 20%, rgba(244, 223, 159, .34), transparent 18%),
+                radial-gradient(circle at 52% 33%, rgba(196, 154, 53, .4), transparent 25%),
+                radial-gradient(circle at 18% 15%, rgba(118, 12, 4, .35), transparent 22%),
+                radial-gradient(circle at 88% 22%, rgba(0, 0, 0, .82), transparent 30%),
+                linear-gradient(135deg, rgba(0, 0, 0, .96), rgba(77, 43, 7, .82) 42%, rgba(40, 39, 43, .84));
+            box-shadow: 0 28px 80px var(--shadow), inset 0 0 110px rgba(0, 0, 0, .72), inset 0 0 80px rgba(196, 154, 53, .18);
+        }
+
+        .hero::before {
+            content: "";
+            position: absolute;
+            inset: auto -10% -28% -10%;
+            height: 48%;
+            background:
+                radial-gradient(ellipse at 18% 100%, rgba(196, 154, 53, .45), transparent 36%),
+                radial-gradient(ellipse at 50% 100%, rgba(111, 9, 2, .62), transparent 42%),
+                radial-gradient(ellipse at 84% 100%, rgba(90, 86, 88, .42), transparent 36%);
+            filter: blur(16px);
+            animation: flamePulse 2.8s ease-in-out infinite;
+        }
+
+        .hero > * { position: relative; z-index: 1; }
+
+        .kicker {
+            display: inline-flex;
+            width: fit-content;
+            margin-bottom: 18px;
+            border: 1px solid rgba(244, 223, 159, .46);
+            border-radius: 999px;
+            padding: 9px 14px;
+            background: rgba(0, 0, 0, .34);
+            color: var(--silver);
+            font-family: Cinzel, Georgia, serif;
+            font-size: 13px;
+            font-weight: 700;
+            letter-spacing: 2.4px;
+            text-transform: uppercase;
+        }
+
+        h1,
+        h2,
+        h3,
+        p { margin-top: 0; }
+
+        h1 {
+            max-width: 1040px;
+            margin: 0 0 10px;
+            font-family: Cinzel, Georgia, serif;
+            font-size: clamp(58px, 11vw, 150px);
+            font-weight: 800;
+            line-height: .88;
+            letter-spacing: clamp(1px, .7vw, 9px);
+            text-transform: uppercase;
+            background:
+                linear-gradient(180deg, #f7f3e8 0%, #a9a391 18%, #f4df9f 48%, #78651f 64%, #f7f3e8 82%, #312b20 100%);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+            -webkit-text-stroke: 1px rgba(0, 0, 0, .76);
+            filter: drop-shadow(0 3px 0 rgba(0, 0, 0, .82)) drop-shadow(0 0 18px rgba(244, 223, 159, .22));
+        }
+
+        .hero-subtitle,
+        .hero-footer-title {
+            font-family: Cinzel, Georgia, serif;
+            text-transform: uppercase;
+            color: var(--silver);
+            text-shadow: 0 2px 0 #000, 0 0 16px rgba(244, 223, 159, .22);
+        }
+
+        .hero-subtitle {
+            margin-bottom: 30px;
+            font-size: clamp(24px, 3.4vw, 46px);
+            letter-spacing: clamp(4px, 1.2vw, 16px);
+        }
+
+        .hero-footer-title {
+            margin-top: clamp(34px, 10vw, 110px);
+            font-size: clamp(28px, 4.5vw, 62px);
+            letter-spacing: clamp(5px, 1.1vw, 14px);
+        }
+
+        .hero-copy {
+            max-width: 760px;
+            color: #e4d7be;
+            font-size: clamp(18px, 2.3vw, 25px);
+            line-height: 1.55;
+        }
+
+        .cta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 14px;
+            margin-top: 28px;
+        }
+
+        .cta {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 18px;
+            padding: 16px 22px;
+            font-weight: 900;
+            box-shadow: 0 16px 32px rgba(0, 0, 0, .24);
+        }
+
+        .cta.primary {
+            background: linear-gradient(135deg, #7a1308, #c49a35 54%, #f4df9f);
+            color: #090604;
+        }
+
+        .cta.secondary {
+            border: 1px solid rgba(244, 223, 159, .32);
+            background: rgba(0, 0, 0, .28);
+            color: var(--silver);
+        }
+
+        .section {
+            position: relative;
+            margin: 56px 0;
+            border: 1px solid var(--border);
+            border-radius: 30px;
+            padding: clamp(24px, 5vw, 52px);
+            background: var(--glass);
+            box-shadow: 0 22px 60px var(--shadow);
+            backdrop-filter: blur(16px);
+        }
+
+        .section.fire {
+            border-color: rgba(196, 154, 53, .28);
+            background:
+                radial-gradient(circle at 50% 0%, rgba(196, 154, 53, .18), transparent 35%),
+                linear-gradient(135deg, rgba(11, 8, 6, .84), rgba(64, 18, 6, .54) 48%, rgba(26, 23, 24, .72));
+        }
+
+        .section.space {
+            border-color: rgba(143, 97, 190, .34);
+            background:
+                radial-gradient(circle at 15% 10%, rgba(21, 27, 111, .32), transparent 28%),
+                radial-gradient(circle at 88% 18%, rgba(143, 97, 190, .26), transparent 30%),
+                linear-gradient(135deg, rgba(3, 4, 20, .9), rgba(25, 17, 62, .82));
+        }
+
+        .section h2 {
+            margin-bottom: 16px;
+            font-family: Cinzel, Georgia, serif;
+            font-size: clamp(34px, 5vw, 72px);
+            font-weight: 700;
+            line-height: .98;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            color: var(--silver);
+            text-shadow: 0 2px 0 #000, 0 0 18px rgba(196, 154, 53, .2);
+        }
+
+        .section h3 {
+            margin-bottom: 10px;
+            font-family: Cinzel, Georgia, serif;
+            font-size: clamp(21px, 2.2vw, 30px);
+            color: var(--gold-bright);
+            letter-spacing: 1px;
+        }
+
+        .lead,
+        .section p,
+        .section li {
+            color: var(--muted);
+            font-size: 17px;
+            line-height: 1.72;
+        }
+
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 18px;
+            margin-top: 24px;
+        }
+
+        .card {
+            border: 1px solid var(--border);
+            border-radius: 22px;
+            padding: 22px;
+            background: rgba(255, 255, 255, .08);
+        }
+
+        .tag-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-top: 22px;
+        }
+
+        .tag {
+            border: 1px solid rgba(255, 255, 255, .16);
+            border-radius: 999px;
+            padding: 9px 12px;
+            color: var(--silver);
+            background: rgba(0, 0, 0, .24);
+            font-size: 13px;
+            font-weight: 800;
+        }
+
+        .cosmic-transition {
+            position: relative;
+            min-height: 360px;
+            display: block;
+            margin: 70px 0;
+            overflow: hidden;
+            border-radius: 34px;
+            border: 1px solid rgba(143, 97, 190, .28);
+            background:
+                radial-gradient(circle at 18% 28%, rgba(196, 154, 53, .18), transparent 14%),
+                radial-gradient(circle at 70% 24%, rgba(46, 66, 170, .38), transparent 24%),
+                radial-gradient(circle at 50% 82%, rgba(143, 97, 190, .32), transparent 28%),
+                linear-gradient(135deg, rgba(6, 4, 3, .9), rgba(8, 10, 42, .94) 52%, rgba(38, 16, 62, .92));
+            box-shadow: inset 0 0 90px rgba(76, 97, 255, .18), 0 28px 80px var(--shadow);
+        }
+
+        .cosmic-transition::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background-image:
+                radial-gradient(circle, rgba(220, 226, 255, .72) 0 1px, transparent 1.6px),
+                radial-gradient(circle, rgba(143, 97, 190, .65) 0 1px, transparent 1.4px);
+            background-size: 74px 74px, 132px 132px;
+            opacity: .55;
+        }
+
+        .moon {
+            position: absolute;
+            border-radius: 50%;
+            background:
+                radial-gradient(circle at 35% 30%, #fff, #d9e6ff 30%, #7b8ebb 68%, #334066);
+            box-shadow: 0 0 40px rgba(190, 210, 255, .55);
+            opacity: .9;
+        }
+
+        .moon.one { width: 128px; height: 128px; left: 7%; top: 12%; }
+        .moon.two { width: 76px; height: 76px; right: 10%; bottom: 14%; opacity: .74; }
+        .moon.three { width: 42px; height: 42px; right: 30%; top: 18%; opacity: .62; }
+
+        .scale-panel {
+            background:
+                radial-gradient(circle at 50% 0%, rgba(244, 223, 159, .22), transparent 24%),
+                rgba(238, 234, 221, .96);
+            color: #050505;
+            border-color: rgba(196, 154, 53, .38);
+        }
+
+        .scale-panel h2 {
+            color: #1c1710;
+            text-align: center;
+            text-shadow: 0 1px 0 rgba(255, 255, 255, .72);
+        }
+
+        .scale-panel .lead {
+            max-width: 820px;
+            margin: 0 auto 30px;
+            color: #454545;
+            text-align: center;
+        }
+
+        .scale {
+            width: min(1500px, 100%);
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 18px;
+            align-items: end;
+            min-height: 560px;
+            margin: 0 auto;
+        }
+
+        .scale-column {
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+            min-width: 0;
+        }
+
+        .scale-label {
+            min-height: 112px;
+            display: flex;
+            align-items: flex-start;
+            justify-content: center;
+            margin-bottom: 24px;
+            text-align: center;
+            color: #050505;
+            font-size: clamp(23px, 3vw, 48px);
+            line-height: 1.15;
+            font-weight: 400;
+        }
+
+        .bar-wrap {
+            height: 390px;
+            display: flex;
+            align-items: flex-end;
+        }
+
+        .bar {
+            width: 100%;
+            min-height: 28px;
+            height: var(--h);
+            border-radius: 54px;
+            cursor: ns-resize;
+            position: relative;
+            user-select: none;
+            background: linear-gradient(180deg, #312aff, #0900ff 58%, #0500a8);
+            box-shadow: 0 8px 20px rgba(0, 0, 0, .08), inset 0 0 18px rgba(255, 255, 255, .18);
+            transition: box-shadow .12s ease, filter .12s ease;
+        }
+
+        .bar:hover,
+        .bar.dragging {
+            filter: brightness(1.08);
+            box-shadow: 0 10px 28px rgba(0, 0, 0, .18), 0 0 24px rgba(9, 0, 255, .28);
+        }
+
+        .value {
+            position: absolute;
+            left: 50%;
+            bottom: 14px;
+            transform: translateX(-50%);
+            color: white;
+            font-size: 22px;
+            font-weight: 800;
+            opacity: .95;
+            pointer-events: none;
+        }
+
+        .scale-controls {
+            width: min(1500px, 100%);
+            margin: 30px auto 0;
+            padding: 18px;
+            border: 1px solid #d7d7d7;
+            border-radius: 18px;
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            justify-content: center;
+            align-items: center;
+            background: #e7e1d0;
+        }
+
+        .scale-controls button {
+            border-color: #bbb;
+            background: #faf7ef;
+            color: #111;
+            box-shadow: none;
+        }
+
+        .hint {
+            width: min(1500px, 100%);
+            margin: 12px auto 0;
+            color: #666;
+            text-align: center;
+            font-size: 15px;
+        }
+
+        .safety-list {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+            gap: 14px;
+            padding: 0;
+            list-style: none;
+        }
+
+        .safety-list li {
+            border: 1px solid rgba(255, 255, 255, .16);
+            border-radius: 18px;
+            padding: 18px;
+            background: rgba(0, 0, 0, .18);
+        }
+
+        .footer {
+            padding: 44px 0 20px;
+            text-align: center;
+            color: rgba(244, 239, 231, .72);
+        }
+
+        @keyframes flamePulse {
+            0%, 100% { transform: translateY(0) scaleX(1); opacity: .82; }
+            50% { transform: translateY(-16px) scaleX(1.06); opacity: 1; }
+        }
+
+        @keyframes starDrift {
+            to { background-position: 240px 360px, -180px 180px, 120px -240px; }
+        }
+
+        @media (max-width: 900px) {
+            .masthead { align-items: flex-start; flex-direction: column; }
+            .nav { justify-content: flex-start; }
+            .hero { min-height: auto; }
+            .grid, .safety-list { grid-template-columns: 1fr; }
+            .scale { gap: 10px; min-height: 500px; }
+            .scale-label { min-height: 92px; font-size: 21px; }
+            .bar-wrap { height: 340px; }
+            .bar { border-radius: 34px; }
+        }
+
+        @media (max-width: 620px) {
+            .page { padding: 16px; }
+            .hero, .section { border-radius: 24px; }
+            h1 { letter-spacing: -2px; }
+            .scale-panel { padding-left: 12px; padding-right: 12px; }
+            .scale { grid-template-columns: repeat(2, minmax(0, 1fr)); min-height: auto; row-gap: 30px; }
+            .bar-wrap { height: 260px; }
+            .moon.one { width: 86px; height: 86px; }
+        }
+    </style>
+</head>
+<body id="top">
+    <canvas id="particle-canvas" class="particle-canvas" aria-hidden="true"></canvas>
+    <main class="page">
+        <header class="masthead" aria-label="Site header">
+            <a class="logo" href="index.html" aria-label="Endless Vocals home">ENDLESS <span style="opacity:.72;font-weight:700">vocals</span></a>
+            <nav class="nav" aria-label="Scream Center navigation">
+                <a href="index.html">Home</a>
+                <a href="#course">Course</a>
+                <a href="#scale">Heaviness Scale</a>
+                <a href="#coming-soon">Coming Soon</a>
+            </nav>
+        </header>
+
+        <section class="hero" aria-labelledby="scream-title">
+            <span class="kicker">Upcoming Course • Harsh Vocals Without Guessing</span>
+            <h1 id="scream-title">Scream Center</h1>
+            <div class="hero-subtitle">Grit &amp; Screams</div>
+            <p class="hero-copy">A new Endless Vocals training course focused on grit, screams, harsh vocals, and aggressive singing—built for singers who want to understand how screams actually work instead of forcing loud sounds and hoping for the best.</p>
+            <div class="cta-row" role="group" aria-label="Scream Center actions">
+                <a class="cta primary" href="#course">Explore the course</a>
+                <a class="cta secondary" href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener noreferrer">Preview in Phase Cycle II</a>
+            </div>
+            <div class="hero-footer-title">Vocal Training Course</div>
+        </section>
+
+        <section id="course" class="section fire" aria-labelledby="course-title">
+            <h2 id="course-title">Break the scream into trainable pieces.</h2>
+            <p class="lead">Scream Center is being built for singers who want a clear map. The course breaks aggressive vocal sounds into ingredients, trains those ingredients one by one, then shows how they connect back into real songs.</p>
+            <p>The course will cover vocal fry, fry screams, frustrated sigh, low grit, grit slides, breathing, support, placement, warm-ups, resets, safety checks, and how to apply these sounds to different genres of music.</p>
+            <p>Scream Center is not about copying one scream style. It is about understanding the ingredients behind different screams so singers can build their own sound safely and confidently.</p>
+            <div class="tag-row" aria-label="Course topics">
+                <span class="tag">Vocal Fry</span>
+                <span class="tag">Fry Screams</span>
+                <span class="tag">Frustrated Sigh</span>
+                <span class="tag">Low Grit</span>
+                <span class="tag">Grit Slides</span>
+                <span class="tag">Safety Resets</span>
+            </div>
+        </section>
+
+        <section class="section fire" aria-labelledby="cover-title">
+            <h2 id="cover-title">What the course will cover</h2>
+            <div class="grid">
+                <article class="card">
+                    <h3>Vocal Fry and Fry Screams</h3>
+                    <p>Students will learn how to start with basic groggy fry, shape it with support and placement, sustain it, and eventually move toward fry scream textures.</p>
+                </article>
+                <article class="card">
+                    <h3>Frustrated Sigh Technique</h3>
+                    <p>The frustrated sigh is one of the most natural gateways into aggressive vocals. The course explores phrases, barks, panting sighs, sustained sighs, and how this sound connects to heavier screams.</p>
+                </article>
+                <article class="card">
+                    <h3>Low Grit</h3>
+                    <p>Low grit is one of the centerpieces of the course. Students will learn how to place grit onto an actual note, return to clean singing, and build a gritty sound that still feels musical.</p>
+                </article>
+                <article class="card">
+                    <h3>Grit Slides</h3>
+                    <p>Students will learn how to move grit through small slides, downward slides, longer slides, and eventually more advanced scream shapes.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="cosmic-transition" aria-hidden="true">
+            <span class="moon one" aria-hidden="true"></span>
+            <span class="moon two" aria-hidden="true"></span>
+            <span class="moon three" aria-hidden="true"></span>
+        </section>
+
+        <section id="scale" class="section scale-panel" aria-labelledby="scale-title">
+            <h2 id="scale-title">Scream Heaviness</h2>
+            <p class="lead">This scream heaviness scale shows how different harsh vocal styles can lean on different ingredient balances. Drag the bars or use a preset to explore the blend.</p>
+
+            <main class="scale" aria-label="Interactive scream heaviness scale">
+                <section class="scale-column">
+                    <div class="scale-label">Vocal Fry<br>+ Fry Scream</div>
+                    <div class="bar-wrap">
+                        <div class="bar" data-name="fry" style="--h: 88%;" title="Drag up or down" role="slider" aria-label="Vocal Fry and Fry Scream" aria-valuemin="6" aria-valuemax="100" aria-valuenow="88" tabindex="0">
+                            <span class="value">88</span>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="scale-column">
+                    <div class="scale-label">Frustrated Sigh</div>
+                    <div class="bar-wrap">
+                        <div class="bar" data-name="sigh" style="--h: 58%;" title="Drag up or down" role="slider" aria-label="Frustrated Sigh" aria-valuemin="6" aria-valuemax="100" aria-valuenow="58" tabindex="0">
+                            <span class="value">58</span>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="scale-column">
+                    <div class="scale-label">Low Grit</div>
+                    <div class="bar-wrap">
+                        <div class="bar" data-name="lowgrit" style="--h: 38%;" title="Drag up or down" role="slider" aria-label="Low Grit" aria-valuemin="6" aria-valuemax="100" aria-valuenow="38" tabindex="0">
+                            <span class="value">38</span>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="scale-column">
+                    <div class="scale-label">Grit Slides</div>
+                    <div class="bar-wrap">
+                        <div class="bar" data-name="slides" style="--h: 53%;" title="Drag up or down" role="slider" aria-label="Grit Slides" aria-valuemin="6" aria-valuemax="100" aria-valuenow="53" tabindex="0">
+                            <span class="value">53</span>
+                        </div>
+                    </div>
+                </section>
+            </main>
+
+            <div class="scale-controls">
+                <button type="button" data-preset="alexi">Children of Bodom / Wintersun</button>
+                <button type="button" data-preset="corpse">Death Metal / Cannibal Corpse</button>
+                <button type="button" data-preset="opeth">Opeth-ish Mix</button>
+                <button type="button" data-preset="screamo">Fry-heavy Screamo</button>
+                <button type="button" data-preset="black">Black Metal</button>
+                <button type="button" data-preset="reset">Reset</button>
+            </div>
+
+            <p class="hint">Drag any blue box up or down to adjust the amount of that ingredient. Use presets to quickly show different scream-style blends in class.</p>
+        </section>
+
+        <section class="section space" aria-labelledby="style-title">
+            <h2 id="style-title">Style application</h2>
+            <p>Scream Center will explore how different scream styles use different balances of vocal fry, frustrated sigh, low grit, and slides. This can apply to styles inspired by black metal, melodic death metal, death metal, screamo, Opeth-style harsh vocals, In Flames-style vocals, Children of Bodom, Wintersun, and more.</p>
+            <p>This gives singers a clear map instead of leaving them guessing.</p>
+        </section>
+
+        <section class="section space" aria-labelledby="safety-title">
+            <h2 id="safety-title">Safety and reset tools</h2>
+            <p>Scream Center will focus on how to stop, reset, and rebuild the sound when tension builds or the voice starts feeling tired.</p>
+            <ul class="safety-list">
+                <li>Gargling tone resets</li>
+                <li>Warm-down routines</li>
+                <li>Clean-note checks</li>
+                <li>Hot water and throat care routines</li>
+            </ul>
+        </section>
+
+        <section class="section space" aria-labelledby="for-title">
+            <h2 id="for-title">Who it’s for</h2>
+            <p>Scream Center is for singers who want to sing with grit, learn harsh vocals, explore metal vocals, or understand aggressive singing in a more structured way.</p>
+            <p>It is especially useful for singers who feel confused by online scream advice, have tried fry screams but feel stuck, lose their voice after harsh vocal sessions, or want a clearer path from exercises into real songs.</p>
+        </section>
+
+        <section id="coming-soon" class="section space" aria-labelledby="soon-title">
+            <h2 id="soon-title">Coming soon</h2>
+            <p>Scream Center is currently in development through Endless Vocals, and the preview is currently inside the Phase Cycle II Bootcamp available for VOD and replaying.</p>
+            <p>This is where we break the scream into pieces, learn how those pieces work, and start building a scream that can actually live inside music.</p>
+            <div class="cta-row">
+                <a class="cta primary" href="https://ko-fi.com/EndlessVocals" target="_blank" rel="noopener noreferrer">Get the Phase Cycle II preview</a>
+                <a class="cta secondary" href="index.html">Back to Endless Vocals</a>
+            </div>
+        </section>
+
+        <footer class="footer">
+            <a class="top-link" href="#top">Back to top</a>
+            <p style="margin-top:20px">© <span id="year"></span> Endless Vocals. All rights reserved.</p>
+        </footer>
+    </main>
+
+    <script>
+        const yearEl = document.getElementById('year');
+        if (yearEl) {
+            yearEl.textContent = new Date().getFullYear();
+        }
+
+        const bars = [...document.querySelectorAll('.bar')];
+        const min = 6;
+        const max = 100;
+
+        function setBar(bar, value) {
+            const clamped = Math.max(min, Math.min(max, Math.round(value)));
+            bar.style.setProperty('--h', `${clamped}%`);
+            bar.querySelector('.value').textContent = clamped;
+            bar.setAttribute('aria-valuenow', clamped);
+        }
+
+        function updateFromPointer(bar, clientY) {
+            const wrap = bar.parentElement;
+            const rect = wrap.getBoundingClientRect();
+            const percent = ((rect.bottom - clientY) / rect.height) * 100;
+            setBar(bar, percent);
+        }
+
+        bars.forEach((bar) => {
+            bar.addEventListener('pointerdown', (event) => {
+                bar.setPointerCapture(event.pointerId);
+                bar.classList.add('dragging');
+                updateFromPointer(bar, event.clientY);
+            });
+
+            bar.addEventListener('pointermove', (event) => {
+                if (bar.classList.contains('dragging')) {
+                    updateFromPointer(bar, event.clientY);
+                }
+            });
+
+            bar.addEventListener('pointerup', () => {
+                bar.classList.remove('dragging');
+            });
+
+            bar.addEventListener('pointercancel', () => {
+                bar.classList.remove('dragging');
+            });
+
+            bar.addEventListener('keydown', (event) => {
+                const current = Number(bar.getAttribute('aria-valuenow')) || min;
+                if (event.key === 'ArrowUp' || event.key === 'ArrowRight') {
+                    event.preventDefault();
+                    setBar(bar, current + 4);
+                }
+                if (event.key === 'ArrowDown' || event.key === 'ArrowLeft') {
+                    event.preventDefault();
+                    setBar(bar, current - 4);
+                }
+                if (event.key === 'Home') {
+                    event.preventDefault();
+                    setBar(bar, min);
+                }
+                if (event.key === 'End') {
+                    event.preventDefault();
+                    setBar(bar, max);
+                }
+            });
+        });
+
+        const presets = {
+            alexi: { fry: 78, sigh: 62, lowgrit: 68, slides: 88 },
+            corpse: { fry: 38, sigh: 92, lowgrit: 82, slides: 35 },
+            opeth: { fry: 58, sigh: 74, lowgrit: 72, slides: 45 },
+            screamo: { fry: 95, sigh: 35, lowgrit: 25, slides: 45 },
+            black: { fry: 72, sigh: 44, lowgrit: 30, slides: 62 },
+            reset: { fry: 88, sigh: 58, lowgrit: 38, slides: 53 },
+        };
+
+        document.querySelectorAll('[data-preset]').forEach((button) => {
+            button.addEventListener('click', () => {
+                const preset = presets[button.dataset.preset];
+                bars.forEach((bar) => {
+                    setBar(bar, preset[bar.dataset.name]);
+                });
+            });
+        });
+
+        const canvas = document.getElementById('particle-canvas');
+        const ctx = canvas ? canvas.getContext('2d') : null;
+        const particles = [];
+        const particleCount = 90;
+
+        function setupCanvas() {
+            if (!canvas || !ctx) return;
+            const width = window.innerWidth || 1;
+            const height = window.innerHeight || 1;
+            const ratio = window.devicePixelRatio || 1;
+            canvas.width = Math.floor(width * ratio);
+            canvas.height = Math.floor(height * ratio);
+            canvas.style.width = `${width}px`;
+            canvas.style.height = `${height}px`;
+            ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+        }
+
+        function seedParticles() {
+            particles.length = 0;
+            const width = window.innerWidth || 1;
+            const height = window.innerHeight || 1;
+            for (let i = 0; i < particleCount; i++) {
+                particles.push({
+                    x: Math.random() * width,
+                    y: Math.random() * height,
+                    vx: (Math.random() - .5) * .65,
+                    vy: Math.random() * -1.4 - .15,
+                    size: Math.random() * 2.6 + .8,
+                    twinkle: Math.random() * Math.PI * 2,
+                });
+            }
+        }
+
+        function drawParticles() {
+            if (!canvas || !ctx) return;
+            const width = window.innerWidth || 1;
+            const height = window.innerHeight || 1;
+            const scrollable = Math.max(1, document.documentElement.scrollHeight - height);
+            const progress = Math.min(1, Math.max(0, window.scrollY / scrollable));
+            const spaceMode = progress > .42;
+
+            ctx.clearRect(0, 0, width, height);
+            particles.forEach((particle) => {
+                particle.twinkle += .035;
+                if (spaceMode) {
+                    particle.x += particle.vx * .62;
+                    particle.y += (particle.vy * .1) + .12;
+                } else {
+                    particle.x += Math.sin(particle.twinkle) * .18;
+                    particle.y += particle.vy;
+                }
+
+                if (particle.y < -20) particle.y = height + 20;
+                if (particle.y > height + 20) particle.y = -20;
+                if (particle.x < -20) particle.x = width + 20;
+                if (particle.x > width + 20) particle.x = -20;
+
+                const glow = .45 + Math.sin(particle.twinkle) * .25;
+                ctx.beginPath();
+                ctx.arc(particle.x, particle.y, particle.size * (spaceMode ? 1 : 1.3), 0, Math.PI * 2);
+                ctx.fillStyle = spaceMode
+                    ? `rgba(${130 + glow * 80}, ${170 + glow * 60}, 255, ${.42 + glow * .28})`
+                    : `rgba(255, ${120 + glow * 95}, ${20 + glow * 45}, ${.34 + glow * .38})`;
+                ctx.shadowColor = spaceMode ? 'rgba(120, 150, 255, .95)' : 'rgba(255, 80, 20, .95)';
+                ctx.shadowBlur = spaceMode ? 12 : 16;
+                ctx.fill();
+            });
+            ctx.shadowBlur = 0;
+            requestAnimationFrame(drawParticles);
+        }
+
+        setupCanvas();
+        seedParticles();
+        drawParticles();
+        window.addEventListener('resize', () => {
+            setupCanvas();
+            seedParticles();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a dedicated landing page for the new Scream Center course so visitors can learn about grit/scream training and related materials. 
- Surface the new page from the homepage via navigation and CTAs so users can easily find the course preview. 
- Improve social preview variety by rotating the OG/Twitter thumbnail across visits to increase visual engagement.

### Description
- Updated `index.html` to add `id="meta-og-image"` and `id="meta-twitter-image"` and injected a self-invoking `rotateSocialThumbnail()` script that cycles a set of preview images and persists the next index in `localStorage`.
- Added a `Scream Center` nav link and a new CTA in the homepage hero to point users to `scream-center.html`.
- Added a new `scream-center.html` landing page implementing a dark-themed design, hero, course overview, topic tags, safety notes, and a responsive layout with accessible markup.
- Implemented an interactive "Scream Heaviness" scale in `scream-center.html` with draggable bars, keyboard controls, named presets, particle canvas background, and a dynamic year display.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b308136e48331ae3b2cb875d4f07a)