### PR TITLE
Change final clean clinic to bonus hangout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,16 +4,16 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Clean to Scream — Endless Vocals Bootcamp III</title>
-    <meta name="description" content="Clean to Scream is now applying the ISO Method to full songs. The final clean-singing clinic is August 29 before Scream Center begins September 8, 2026." />
+    <meta name="description" content="Clean to Scream is now applying the ISO Method to full songs. An August 29 hangout with bonus techniques comes next before Scream Center begins September 8, 2026." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://endlessvocals.com/" />
     <meta property="og:title" content="Clean to Scream — Endless Vocals Bootcamp III" />
-    <meta property="og:description" content="Four clean-singing clinics are complete. Song application is next, followed by Scream Center beginning September 8, 2026." />
+    <meta property="og:description" content="Four clean-singing clinics are complete. A hangout with bonus techniques is next, followed by Scream Center beginning September 8, 2026." />
     <meta property="og:image" content="https://endlessvocals.com/images/clean-to-scream-bootcamp.jpg" />
     <meta property="og:image:alt" content="Clean to Scream by Endless Vocals, August and September 2026" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Clean to Scream — Endless Vocals Bootcamp III" />
-    <meta name="twitter:description" content="Four clean-singing clinics are complete. Song application is next, followed by Scream Center beginning September 8, 2026." />
+    <meta name="twitter:description" content="Four clean-singing clinics are complete. A hangout with bonus techniques is next, followed by Scream Center beginning September 8, 2026." />
     <meta name="twitter:image" content="https://endlessvocals.com/images/clean-to-scream-bootcamp.jpg" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1064,7 +1064,7 @@
                 <div>
                     <span class="hero-kicker">Bootcamp III • Clinic 4 complete</span>
                     <h1 id="h1" class="title">Clean to Scream</h1>
-                    <p class="subtitle">Four clean-singing clinics are complete. We have moved from stress release, support, and ISO exercises into singing songs with the Vocal Strength Trainer. Next, we apply that work directly to songs before Scream Center begins in September.</p>
+                    <p class="subtitle">Four clean-singing clinics are complete. We have moved from stress release, support, and ISO exercises into singing songs with the Vocal Strength Trainer. Next is a hangout with bonus techniques before Scream Center begins in September.</p>
                     <div class="cta-row" role="group" aria-label="Primary actions">
                         <a class="btn btn-primary" href="join.html" aria-label="Join Endless Vocals">
                             <span>JOIN!</span>
@@ -1102,7 +1102,7 @@
                     <p>One focused live session at a time, followed by space to practice. The latest clinic brought the ISO foundation into songs and the Vocal Strength Trainer. Every class is recorded for members.</p>
                     <div class="list" aria-label="Program highlights">
                         <div class="item">Now: Singing Songs + Vocal Strength Trainer App</div>
-                        <div class="item">Next: Song Application + Warm-down on August 29</div>
+                        <div class="item">Next: Hangout + Bonus Techniques on August 29</div>
                         <div class="item">Then: Scream Center begins September 8</div>
                     </div>
                 </section>
@@ -1115,7 +1115,7 @@
             <section class="clinic-progress" aria-labelledby="clinic-progress-title">
                 <span class="month-label">Where we are now</span>
                 <h2 id="clinic-progress-title">The clean foundation is moving into songs.</h2>
-                <p>Clinic 4 is complete. One clean-singing session remains before the course shifts into the Scream Center progression.</p>
+                <p>Clinic 4 is complete. One August hangout with bonus techniques remains before the course shifts into the Scream Center progression.</p>
                 <div class="clinic-progress-grid">
                     <div class="clinic-progress-step">
                         <span class="clinic-progress-label">Latest clinic • Complete</span>
@@ -1125,7 +1125,7 @@
                     <span class="clinic-progress-arrow" aria-hidden="true">→</span>
                     <div class="clinic-progress-step next">
                         <span class="clinic-progress-label">Next live clinic</span>
-                        <strong>Song Application + Warm-down</strong>
+                        <strong>Hangout + Bonus Techniques</strong>
                         <time class="js-local-time" datetime="2026-08-29T16:00:00Z">Saturday, August 29 at 9:00 AM PT</time>
                     </div>
                 </div>
@@ -1143,7 +1143,7 @@
                         <li class="is-complete"><strong>Technique — Breathing, Support + Placement</strong><time class="js-local-time" datetime="2026-08-11T01:00:00Z">Monday, August 10 at 6:00 PM PT</time></li>
                         <li class="is-complete"><strong>ISO Exercises — Falsetto Slides, Transcending Tones + Vendera Sirens</strong><time class="js-local-time" datetime="2026-08-15T16:00:00Z">Saturday, August 15 at 9:00 AM PT</time></li>
                         <li class="is-latest"><strong>Singing Songs + Vocal Strength Trainer App</strong><time class="js-local-time" datetime="2026-08-25T01:00:00Z">Monday, August 24 at 6:00 PM PT</time></li>
-                        <li class="is-next"><strong>Song Application + Warm-down</strong><time class="js-local-time" datetime="2026-08-29T16:00:00Z">Saturday, August 29 at 9:00 AM PT</time></li>
+                        <li class="is-next"><strong>Hangout + Bonus Techniques</strong><time class="js-local-time" datetime="2026-08-29T16:00:00Z">Saturday, August 29 at 9:00 AM PT</time></li>
                     </ul>
                 </article>
 


### PR DESCRIPTION
Changes the August 29 final clean clinic from Song Application + Warm-down to Hangout + Bonus Techniques everywhere it appears, including the homepage progress state and social descriptions. Desktop and mobile smoke checks pass.